### PR TITLE
[UE5.6] Fix failing action where we build against public deps

### DIFF
--- a/.changeset/loud-radios-happen.md
+++ b/.changeset/loud-radios-happen.md
@@ -1,0 +1,5 @@
+---
+'@epicgames-ps/lib-pixelstreamingfrontend-ue5.6': patch
+---
+
+When building the frontend library not in this repository it would fail due requiring newer node types, so these were added a dev dep.

--- a/Frontend/library/package.json
+++ b/Frontend/library/package.json
@@ -29,7 +29,8 @@
         "rimraf": "^6.0.1",
         "ts-jest": "^29.2.5",
         "typescript": "^5.7.3",
-        "typescript-eslint": "^8.24.0"
+        "typescript-eslint": "^8.24.0",
+        "@types/node": "^22.14.0"
     },
     "dependencies": {
         "@epicgames-ps/lib-pixelstreamingcommon-ue5.6": "^0.1.3",


### PR DESCRIPTION
## Relevant components:
- [x] Frontend library

## Problem statement:
Failing GHA https://github.com/EpicGamesExt/PixelStreamingInfrastructure/actions/runs/17635121188/job/50109770521

## Solution
While our monorepo root has the correct deps on types once we build against public deps we do not have this root of the repo helping us any more so we need to declare it explicitly, see: https://stackoverflow.com/a/78790944

## Documentation
N/A

## Test Plan and Compatibility
Testing the failing GHA
