### PR TITLE
Reverse order of High, Medium, Low quality settings to match 5.7 logic

### DIFF
--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -1389,7 +1389,7 @@ export class WebRtcPlayerController {
         if (this.isUsingSFU) {
             if (!this.isUsingSVC) {
                 // User is using an SFU without any temporal scalability. Just offer easily readable names
-                availableQualities = ['Low', 'Medium', 'High'];
+                availableQualities = ['High', 'Medium', 'Low'];
             } else {
                 // User is using SVC. Generate all available options.
                 availableQualities = [];
@@ -1407,7 +1407,7 @@ export class WebRtcPlayerController {
         this.config.setOptionSettingOptions(OptionParameters.PreferredQuality, availableQualities);
 
         // Update the selected video quality with the highest possible resolution
-        this.config.setOptionSettingValue(OptionParameters.PreferredQuality, availableQualities.slice(-1)[0]);
+        this.config.setOptionSettingValue(OptionParameters.PreferredQuality, availableQualities[0]);
 
         const sdpOffer: RTCSessionDescriptionInit = {
             sdp: Offer.sdp,


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [X] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
With updates to PS2 in UE5.7, the order of layer qualities has reversed. Currently, selecting `High` on the Frontend will give the lowest quality.

## Solution
Reverse the order of the options to reflect the correct order.