### PR TITLE
Make generateStats not error if peerconnection is undefined

### DIFF
--- a/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
+++ b/Frontend/library/src/PeerConnectionController/PeerConnectionController.ts
@@ -171,7 +171,7 @@ export class PeerConnectionController {
      * Generate Aggregated Stats and then fire a onVideo Stats event
      */
     generateStats() {
-        this.peerConnection.getStats().then((statsData: RTCStatsReport) => {
+        this.peerConnection?.getStats().then((statsData: RTCStatsReport) => {
             this.aggregatedStats.processStats(statsData);
 
             this.onVideoStats(this.aggregatedStats);


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Fix for throwing error when peerConnection is not defined

## Solution
Method is not called when object is not defined

## Documentation
If you added a new feature or changed an existing feature please add some documentation here.

Or better yet, link to the relevant `/Docs` update in your PR.

## Test Plan and Compatibility
What steps have you taken to ensure this PR maintains compataibility with the existing functionality? 

Or better yet, link to the unit tests that accompany this PR.
