### PR TITLE
Expose playerid for programmatic access

### DIFF
--- a/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
+++ b/Frontend/library/src/WebRtcPlayer/WebRtcPlayerController.ts
@@ -109,6 +109,7 @@ export class WebRtcPlayerController {
     signallingUrlBuilder: () => string;
     autoJoinTimer: ReturnType<typeof setTimeout> = undefined;
     keepalive: KeepaliveMonitor;
+    playerId: string | null = null;
 
     /**
      *
@@ -1358,6 +1359,11 @@ export class WebRtcPlayerController {
     handleWebRtcAnswer(Answer: Messages.answer) {
         Logger.Info(`Got answer sdp ${Answer.sdp}`);
 
+        // Extract the player id if it is present
+        if (Answer.playerId) {
+            this.playerId = Answer.playerId;
+        }
+
         const sdpAnswer: RTCSessionDescriptionInit = {
             sdp: Answer.sdp,
             type: 'answer'
@@ -1373,6 +1379,11 @@ export class WebRtcPlayerController {
      */
     handleWebRtcOffer(Offer: Messages.offer) {
         Logger.Info(`Got offer sdp ${Offer.sdp}`);
+
+        // Extract the player id if it is present
+        if (Offer.playerId) {
+            this.playerId = Offer.playerId;
+        }
 
         this.isUsingSFU = Offer.sfu ? Offer.sfu : false;
         this.isUsingSVC = Offer.scalabilityMode ? Offer.scalabilityMode != 'L1T1' : false;

--- a/Signalling/src/StreamerConnection.ts
+++ b/Signalling/src/StreamerConnection.ts
@@ -136,7 +136,6 @@ export class StreamerConnection extends EventEmitter implements IStreamer, LogUt
         } else {
             const player = this.server.playerRegistry.get(message.playerId);
             if (player) {
-                delete message.playerId;
                 LogUtils.logForward(this, player, message);
                 player.protocol.sendMessage(message);
             }


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [x] Frontend library

## Problem statement:
It is useful to be able to use the player id as a unique identifier that is common between UE side stats and frontend side stats; however, the player id is not actually exposed to TS/JS because the SS strips it out of signalling messages.

## Solution

- Make SS not strip the player id
- Expose the `playerId` as a field that is accessible


## Test Plan and Compatibility
I ran this locally and was able to access the `playerId` using the `window.pixelStreaming` using my developer console in Chrome.
