### PR TITLE
SecurityError: Failed to execute 'isSessionSupported' on 'XRSystem' when in iframe

### DIFF
--- a/Frontend/library/src/WebXR/WebXRController.ts
+++ b/Frontend/library/src/WebXR/WebXRController.ts
@@ -491,7 +491,9 @@ export class WebXRController {
             if (navigator.xr) {
                 return navigator.xr.isSessionSupported(mode);
             }
-        } catch {}
+        } catch {
+            return Promise.resolve(false);
+        }
 
         return Promise.resolve(false);
     }

--- a/Frontend/library/src/WebXR/WebXRController.ts
+++ b/Frontend/library/src/WebXR/WebXRController.ts
@@ -485,6 +485,8 @@ export class WebXRController {
             Logger.Info('WebXR requires https, if you want WebXR use https.');
         }
 
+        // Wrap in try-catch because access to XR object can be denied due
+        // to browser security permissions (e.g. streaming from an iframe)
         try {
             if (navigator.xr) {
                 return navigator.xr.isSessionSupported(mode);

--- a/Frontend/library/src/WebXR/WebXRController.ts
+++ b/Frontend/library/src/WebXR/WebXRController.ts
@@ -485,12 +485,12 @@ export class WebXRController {
             Logger.Info('WebXR requires https, if you want WebXR use https.');
         }
 
-        if (navigator.xr) {
-            return navigator.xr.isSessionSupported(mode);
-        } else {
-            return new Promise<boolean>(() => {
-                return false;
-            });
-        }
+        try {
+            if (navigator.xr) {
+                return navigator.xr.isSessionSupported(mode);
+            }
+        } catch {}
+
+        return Promise.resolve(false);
     }
 }


### PR DESCRIPTION
fixes: #722

## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [x] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
What problem does this PR address?
#722 

## Solution
How does this PR solve the problem?
Wraps the check in a try catch block and returns false if it throws

## Test Plan and Compatibility
What steps have you taken to ensure this PR maintains compataibility with the existing functionality? 
It only fixes a bug, does not introduce any changes to code paths.
