### PR TITLE
Viewport resolution scale parameter

### DIFF
--- a/Frontend/Docs/Settings Panel.md
+++ b/Frontend/Docs/Settings Panel.md
@@ -31,6 +31,7 @@ This page will be updated with new features and commands as they become availabl
 | **Setting** | **Description** |
 | --- | --- |
 | **Match viewport resolution** | Resizes the Unreal Engine application resolution to match the browser's video element size.|
+| **Viewport Resolution Scale** | Scale factor for viewport resolution when Match Viewport Resolution is enabled. Range: 0.1-10.0, Default: 1.0. Values above 1.0 (e.g., 1.5, 2.0) can improve visual quality on small screens by requesting higher resolution streams. |
 | **Control scheme** | If the scheme is `locked mouse` the browser will use `pointerlock` to capture your mouse, whereas if the scheme is `hovering mouse` you will retain your OS/browser cursor. |
 | **Color scheme** | Allows you to switch between light mode and dark mode. |
 

--- a/Frontend/library/src/Config/Config.ts
+++ b/Frontend/library/src/Config/Config.ts
@@ -65,6 +65,7 @@ export class NumericParameters {
     static MaxReconnectAttempts = 'MaxReconnectAttempts' as const;
     static StreamerAutoJoinInterval = 'StreamerAutoJoinInterval' as const;
     static KeepaliveDelay = 'KeepaliveDelay' as const;
+    static ViewportResolutionScale = 'ViewportResScale' as const;
 }
 
 export type NumericParametersKeys = Exclude<keyof typeof NumericParameters, 'prototype'>;
@@ -818,6 +819,22 @@ export class Config {
                 settings && Object.prototype.hasOwnProperty.call(settings, NumericParameters.KeepaliveDelay)
                     ? settings[NumericParameters.KeepaliveDelay]
                     : 30000 /*value*/,
+                useUrlParams
+            )
+        );
+
+        this.numericParameters.set(
+            NumericParameters.ViewportResolutionScale,
+            new SettingNumber(
+                NumericParameters.ViewportResolutionScale,
+                'Viewport Resolution Scale',
+                'Scale factor for viewport resolution when MatchViewportResolution is enabled. 1.0 = 100%, 0.5 = 50%, 2.0 = 200%.',
+                0.1 /*min*/,
+                10.0 /*max*/,
+                settings &&
+                Object.prototype.hasOwnProperty.call(settings, NumericParameters.ViewportResolutionScale)
+                    ? settings[NumericParameters.ViewportResolutionScale]
+                    : 1.0 /*value*/,
                 useUrlParams
             )
         );

--- a/Frontend/library/src/VideoPlayer/VideoPlayer.ts
+++ b/Frontend/library/src/VideoPlayer/VideoPlayer.ts
@@ -1,6 +1,6 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
-import { Config, Flags } from '../Config/Config';
+import { Config, Flags, NumericParameters } from '../Config/Config';
 import { Logger } from '@epicgames-ps/lib-pixelstreamingcommon-ue5.7';
 
 /**
@@ -222,9 +222,13 @@ export class VideoPlayer {
                 return;
             }
 
+            const viewportResolutionScale = this.config.getNumericSettingValue(
+                NumericParameters.ViewportResolutionScale
+            );
+
             this.onMatchViewportResolutionCallback(
-                videoElementParent.clientWidth,
-                videoElementParent.clientHeight
+                videoElementParent.clientWidth * viewportResolutionScale,
+                videoElementParent.clientHeight * viewportResolutionScale
             );
 
             this.lastTimeResized = new Date().getTime();


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [x] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
When connecting from an iPhone or small screen device with MatchViewportRes set to true, the rendered resolution appears quite low, causing the visuals to look slightly pixelated.

More info here: https://github.com/EpicGamesExt/PixelStreamingInfrastructure/issues/721

## Solution
Added a new numeric parameter ViewportResolutionScale that multiplies the resolution dimensions sent to the onMatchViewportResolutionCallback when MatchViewportResolution is enabled. The scale factor is applied to both width and height in VideoPlayer.updateVideoStreamSize(), allowing users to request higher resolution streams (e.g., 1.5x or 2.0x) to improve visual quality on small screens.

## Documentation
The new ViewportResolutionScale parameter is documented in Frontend/Docs/Settings Panel.md under the UI section.

## Test Plan and Compatibility
Existing unit tests: Config.test.ts automatically covers the new parameter via the "should populate initial values for all settings" test (line 42-49), which validates all numeric parameters are registered