### PR TITLE
[UE5.6] Updating npm publish action for new OIDC npmjs authentication. (#746)

### DIFF
--- a/.github/workflows/changesets-publish-npm-packages.yml
+++ b/.github/workflows/changesets-publish-npm-packages.yml
@@ -11,6 +11,10 @@ on:
 # This makes the matrix of jobs to run one at a time.
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   # gets all publishable npm packages.
   fetch-package-info:

--- a/Signalling/package.json
+++ b/Signalling/package.json
@@ -50,6 +50,6 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/EpicGames/PixelStreamingInfrastructure.git"
+        "url": "https://github.com/EpicGamesExt/PixelStreamingInfrastructure"
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.6`:
 - [Updating npm publish action for new OIDC npmjs authentication. (#746)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/746)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)