### PR TITLE
Fix: incorrect string length when emitting descriptors with non-ASCII characters

### DIFF
--- a/Frontend/library/src/UeInstanceMessage/SendMessageController.ts
+++ b/Frontend/library/src/UeInstanceMessage/SendMessageController.ts
@@ -62,7 +62,6 @@ export class SendMessageController {
         }
 
         let byteLength = 0;
-        const textEncoder = new TextEncoder();
         // One loop to calculate the length in bytes of all of the provided data
         messageData.forEach((element: number | string, idx: number) => {
             const type = messageFormat.structure[idx];
@@ -90,8 +89,8 @@ export class SendMessageController {
                 case 'string':
                     // 2 bytes for string length
                     byteLength += 2;
-                    // 2 bytes per characters
-                    byteLength += 2 * textEncoder.encode(element as string).length;
+                    // 2 bytes per character
+                    byteLength += 2 * (element as string).length;
                     break;
             }
         });


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [X] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
As mentioned in https://github.com/EpicGamesExt/PixelStreamingInfrastructure/issues/754, when emitting a UI interaction with non-ascii characters, the calculated `byteLength` is incorrect.

## Solution
Remove the unnecessary usage of `textEncoder` and use the direct string length.

## Test Plan and Compatibility
Tested with UE 5.7 (PixelStreaming2)
