### PR TITLE
fix: start server when rest_api is enabled and gate static file servi…

### DIFF
--- a/.changeset/silent-lemons-shine.md
+++ b/.changeset/silent-lemons-shine.md
@@ -1,0 +1,6 @@
+---
+"@epicgames-ps/wilbur": patch
+"@epicgames-ps/lib-pixelstreamingsignalling-ue5.7": minor
+---
+
+Make the REST API reachable when Wilbur is started with `--rest_api` but without `--serve`. Previously the Express app that hosts the `/api/*` routes was only bound to an HTTP listener inside the `serve` branch, so with `--serve=false --rest_api=true` the listener never started and requests were answered by the WebSocket upgrade handler on the player port (`426 Upgrade Required`). The HTTP listener now starts whenever `rest_api` or `serve` is set. Static file serving and the homepage route are gated by a new `IWebServerConfig.serveStatic` flag (the port listener runs independently of static serving), and the rate limiter is registered before any route handlers so the homepage and any downstream-registered routes are all rate-limited. Wilbur logs at startup which mode it is running in.

--- a/Signalling/src/WebServer.ts
+++ b/Signalling/src/WebServer.ts
@@ -40,7 +40,11 @@ export interface IWebServerConfig {
     // If true, connections to http will be redirected to https.
     https_redirect?: boolean;
 
-    serve?: boolean;
+    // If true, serve static content from `root` and a homepage handler at `/`.
+    // Defaults to false. When false, the HTTP listener still runs (so routes
+    // registered by other subsystems, such as a REST API, remain reachable),
+    // but no static files are served.
+    serveStatic?: boolean;
 }
 
 /**
@@ -113,7 +117,17 @@ export class WebServer {
             }
         }
 
-        if (config.serve) {
+        const limiter = RateLimit({
+            windowMs: 60 * 1000, // 1 minute
+            max: config.perMinuteRateLimit ? config.perMinuteRateLimit : 3000
+        });
+
+        // apply rate limiter to all requests. Registered before any route
+        // handler so that static files, the homepage route, and any routes
+        // registered on `app` by downstream code are all subject to it.
+        app.use(limiter);
+
+        if (config.serveStatic) {
             app.use(express.static(config.root));
 
             // Request has been sent to site root, send the homepage file
@@ -133,14 +147,6 @@ export class WebServer {
                 return;
             });
         }
-
-        const limiter = RateLimit({
-            windowMs: 60 * 1000, // 1 minute
-            max: config.perMinuteRateLimit ? config.perMinuteRateLimit : 3000
-        });
-
-        // apply rate limiter to all requests
-        app.use(limiter);
 
         /* eslint-enable @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access */
     }

--- a/Signalling/src/WebServer.ts
+++ b/Signalling/src/WebServer.ts
@@ -39,6 +39,8 @@ export interface IWebServerConfig {
 
     // If true, connections to http will be redirected to https.
     https_redirect?: boolean;
+
+    serve?: boolean;
 }
 
 /**
@@ -111,7 +113,26 @@ export class WebServer {
             }
         }
 
-        app.use(express.static(config.root));
+        if (config.serve) {
+            app.use(express.static(config.root));
+
+            // Request has been sent to site root, send the homepage file
+            app.get('/', function (req: any, res: any) {
+                // Try a few paths, see if any resolve to a homepage file the user has set
+                const p = path.resolve(path.join(config.root, config.homepageFile));
+                if (fs.existsSync(p)) {
+                    // Send the file for browser to display it
+                    res.sendFile(p);
+                    return;
+                }
+
+                // Catch file doesn't exist, and send back 404 if not
+                const error = 'Unable to locate file ' + config.homepageFile;
+                Logger.error(error);
+                res.status(404).send(error);
+                return;
+            });
+        }
 
         const limiter = RateLimit({
             windowMs: 60 * 1000, // 1 minute
@@ -120,23 +141,6 @@ export class WebServer {
 
         // apply rate limiter to all requests
         app.use(limiter);
-
-        // Request has been sent to site root, send the homepage file
-        app.get('/', function (req: any, res: any) {
-            // Try a few paths, see if any resolve to a homepage file the user has set
-            const p = path.resolve(path.join(config.root, config.homepageFile));
-            if (fs.existsSync(p)) {
-                // Send the file for browser to display it
-                res.sendFile(p);
-                return;
-            }
-
-            // Catch file doesn't exist, and send back 404 if not
-            const error = 'Unable to locate file ' + config.homepageFile;
-            Logger.error(error);
-            res.status(404).send(error);
-            return;
-        });
 
         /* eslint-enable @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access */
     }

--- a/SignallingWebServer/src/index.ts
+++ b/SignallingWebServer/src/index.ts
@@ -247,10 +247,15 @@ if (shouldServerStart) {
     const webserverOptions: IWebServerConfig = {
         httpPort: options.player_port,
         root: options.http_root,
-        homepageFile: options.homepage
+        homepageFile: options.homepage,
+        serveStatic: options.serve
     };
 
-    webserverOptions.serve = options.serve;
+    if (options.serve) {
+        Logger.info('Static file serving enabled.');
+    } else if (options.rest_api) {
+        Logger.info('REST API enabled; static file serving disabled.');
+    }
 
     if (options.https) {
         webserverOptions.httpsPort = options.https_port;

--- a/SignallingWebServer/src/index.ts
+++ b/SignallingWebServer/src/index.ts
@@ -242,12 +242,16 @@ const serverOpts: IServerConfig = {
     maxSubscribers: options.max_players
 };
 
-if (options.serve) {
+const shouldServerStart = options.serve || options.rest_api;
+if (shouldServerStart) {
     const webserverOptions: IWebServerConfig = {
         httpPort: options.player_port,
         root: options.http_root,
         homepageFile: options.homepage
     };
+
+    webserverOptions.serve = options.serve;
+
     if (options.https) {
         webserverOptions.httpsPort = options.https_port;
         const sslKeyPath = path.join(__dirname, '..', options.ssl_key_path);


### PR DESCRIPTION
Fixes #767

## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
When `serve=false` and `rest_api=true`, the REST API is not accessible.

Although the REST API routes and middleware are registered on the Express app via the OpenAPI initialize(...) call, the HTTP/HTTPS server is only started when serve=true through the WebServer. As a result, no server is listening to handle incoming API requests, which can lead to unexpected responses (e.g. 426 Upgrade Required).

## Solution
Start the server when either `serve` or `rest_api` is enabled.

Additionally, static file serving (`express.static`) and the `/` homepage route are now conditionally applied only when `serve=true`.

This ensures:
- The REST API is accessible when `rest_api=true`
- Static content is only served when explicitly enabled via `serve`

Note: This change keeps the existing configuration structure. Fully separating server startup and static file serving would require introducing a dedicated configuration option (e.g. `serve_static`), which is outside the scope of this fix.

## Documentation
No documentation changes required.

## Test Plan and Compatibility
- Verified that:
  - `serve=false` and `rest_api=true` → API is accessible
  - `serve=true` → static files and homepage are served as before
  - `serve=true` and `rest_api=true` → both API and static content work as expected

- Existing behavior for static file serving remains unchanged when `serve=true`

- Changes are limited to:
  - `SignallingWebServer/src/WebServer.ts`
  - `SignallingWebServer/src/index.ts`
  
  
  This Markdown was written with AI i wrote the code by hand 