### PR TITLE
[UE5.5] chore(deps): bump lodash in the npm_and_yarn group across 1 directory (#777)

### DIFF
--- a/Extras/mediasoup-sdp-bridge/package.json
+++ b/Extras/mediasoup-sdp-bridge/package.json
@@ -45,7 +45,7 @@
     "awaitqueue": "^2.1.1",
     "debug": "^4.1.1",
     "h264-profile-level-id": "^1.0.1",
-    "lodash": "^4.0.0",
+    "lodash": "^4.17.23",
     "sdp-transform": "^2.14.0",
     "supports-color": "^7.1.0",
     "uuid": "^8.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -863,7 +863,7 @@
                 "awaitqueue": "^2.1.1",
                 "debug": "^4.1.1",
                 "h264-profile-level-id": "^1.0.1",
-                "lodash": "^4.0.0",
+                "lodash": "^4.17.23",
                 "sdp-transform": "^2.14.0",
                 "supports-color": "^7.1.0",
                 "uuid": "^8.1.0"
@@ -15636,7 +15636,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
             "license": "MIT"
         },
         "node_modules/lodash.memoize": {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.5`:
 - [chore(deps): bump lodash in the npm_and_yarn group across 1 directory (#777)](https://github.com/EpicGamesExt/PixelStreamingInfrastructure/pull/777)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)