### PR TITLE
fix(eslint): pin tsconfigRootDir so lint works from any CWD

### DIFF
--- a/.changeset/quiet-foxes-dance.md
+++ b/.changeset/quiet-foxes-dance.md
@@ -1,0 +1,9 @@
+---
+"@epicgames-ps/lib-pixelstreamingcommon-ue5.7": patch
+"@epicgames-ps/lib-pixelstreamingsignalling-ue5.7": patch
+"@epicgames-ps/wilbur": patch
+"@epicgames-ps/lib-pixelstreamingfrontend-ue5.7": patch
+"@epicgames-ps/lib-pixelstreamingfrontend-ui-ue5.7": patch
+---
+
+Make `npm run lint` work regardless of the directory it's invoked from. Each workspace's `eslint.config.mjs` now pins `parserOptions.tsconfigRootDir` to `import.meta.dirname`, so `parserOptions.project` resolves relative to the config file's own directory rather than whichever CWD `typescript-eslint` happens to pick by default. Previously the six workspace configs prefixed `project` with the workspace directory (e.g. `'Common/tsconfig.cjs.json'`), which only worked under one specific `typescript-eslint` version's resolution behavior and broke CI when run from within the workspace.

--- a/Common/eslint.config.mjs
+++ b/Common/eslint.config.mjs
@@ -13,7 +13,8 @@ export default tseslint.config(
         languageOptions: {
             parser: tseslint.parser,
             parserOptions: {
-                project: 'Common/tsconfig.cjs.json',
+                project: 'tsconfig.cjs.json',
+                tsconfigRootDir: import.meta.dirname,
             },
         },
         files: ["src/**/*.ts"],

--- a/Extras/JSStreamer/eslint.config.mjs
+++ b/Extras/JSStreamer/eslint.config.mjs
@@ -13,7 +13,8 @@ export default tseslint.config(
         languageOptions: {
             parser: tseslint.parser,
             parserOptions: {
-                project: 'Extras/JSStreamer/tsconfig.cjs.json',
+                project: 'tsconfig.cjs.json',
+                tsconfigRootDir: import.meta.dirname,
             },
         },
         files: ["src/**/*.ts"],

--- a/Frontend/library/eslint.config.mjs
+++ b/Frontend/library/eslint.config.mjs
@@ -12,7 +12,8 @@ export default tseslint.config(
         languageOptions: {
             parser: tseslint.parser,
             parserOptions: {
-                project: 'Frontend/library/tsconfig.json',
+                project: 'tsconfig.json',
+                tsconfigRootDir: import.meta.dirname,
             },
         },
         files: ["src/**/*.ts"],

--- a/Frontend/ui-library/eslint.config.mjs
+++ b/Frontend/ui-library/eslint.config.mjs
@@ -12,7 +12,8 @@ export default tseslint.config(
         languageOptions: {
             parser: tseslint.parser,
             parserOptions: {
-                project: 'Frontend/ui-library/tsconfig.json',
+                project: 'tsconfig.json',
+                tsconfigRootDir: import.meta.dirname,
             },
         },
         files: ["src/**/*.ts"],

--- a/Signalling/eslint.config.mjs
+++ b/Signalling/eslint.config.mjs
@@ -13,7 +13,8 @@ export default tseslint.config(
         languageOptions: {
             parser: tseslint.parser,
             parserOptions: {
-                project: 'Signalling/tsconfig.cjs.json',
+                project: 'tsconfig.cjs.json',
+                tsconfigRootDir: import.meta.dirname,
             },
         },
         files: ["src/**/*.ts"],

--- a/SignallingWebServer/eslint.config.mjs
+++ b/SignallingWebServer/eslint.config.mjs
@@ -14,7 +14,8 @@ export default tseslint.config(
         languageOptions: {
             parser: tseslint.parser,
             parserOptions: {
-                project: 'SignallingWebServer/tsconfig.json',
+                project: 'tsconfig.json',
+                tsconfigRootDir: import.meta.dirname,
             },
         },
         files: ["src/**/*.ts"],


### PR DESCRIPTION
Each workspace's eslint.config.mjs set parserOptions.project to a workspace-prefixed path (e.g. 'Common/tsconfig.cjs.json') on the assumption that typescript-eslint resolves it relative to the repo root. That assumption holds only for some versions of typescript-eslint and breaks outright when lint is invoked with CWD = workspace dir — which is exactly how .github/workflows/healthcheck-libraries.yml runs it (working-directory: Common, etc.).

Pin parserOptions.tsconfigRootDir to import.meta.dirname so the relative project path is always resolved against the eslint config file's own directory, regardless of CWD or typescript-eslint version. Drop the workspace prefix from project accordingly.
