### PR TITLE
Add optional server-side player keepalive to reap dead connections

### DIFF
--- a/.changeset/server-player-keepalive.md
+++ b/.changeset/server-player-keepalive.md
@@ -1,0 +1,6 @@
+---
+'@epicgames-ps/lib-pixelstreamingsignalling-ue5.7': patch
+'@epicgames-ps/wilbur': patch
+---
+
+Add an optional server-side keepalive that disconnects players whose connection has died without a clean close. Previously `KeepaliveMonitor` was only used on the client, so a player whose socket dropped silently (sleeping laptop, lost Wi-Fi, killed tab) stayed subscribed until the OS TCP keepalive reaped it, which could hold a `maxSubscribers` slot in the meantime. The new `IServerConfig.playerKeepaliveTimeout` controls this; the signalling server exposes it as `--player_keepalive_timeout <milliseconds>` (default 30000, 0 disables).

--- a/Signalling/src/SignallingServer.ts
+++ b/Signalling/src/SignallingServer.ts
@@ -8,7 +8,12 @@ import { SFUConnection } from './SFUConnection';
 import { Logger } from './Logger';
 import { StreamerRegistry } from './StreamerRegistry';
 import { PlayerRegistry } from './PlayerRegistry';
-import { Messages, MessageHelpers, SignallingProtocol } from '@epicgames-ps/lib-pixelstreamingcommon-ue5.7';
+import {
+    Messages,
+    MessageHelpers,
+    SignallingProtocol,
+    KeepaliveMonitor
+} from '@epicgames-ps/lib-pixelstreamingcommon-ue5.7';
 import { stringify } from './Utils';
 
 /**
@@ -45,6 +50,10 @@ export interface IServerConfig {
 
     // Max number of players per streamer.
     maxSubscribers?: number;
+
+    // Idle timeout in milliseconds after which a player that has stopped responding to keepalive
+    // pings is forcibly disconnected. 0 (the default) disables the check.
+    playerKeepaliveTimeout?: number;
 }
 
 export type ProtocolConfig = {
@@ -158,6 +167,25 @@ export class SignallingServer {
             this.playerRegistry.remove(newPlayer);
             Logger.info(`Player %s (%s) disconnected.`, newPlayer.playerId, request.socket.remoteAddress);
         });
+
+        // Optionally monitor the player connection for liveness. A player whose socket dies without
+        // a clean close frame (sleeping laptop, dropped Wi-Fi, killed tab) is otherwise only removed
+        // once the OS TCP keepalive eventually reaps it, leaving it subscribed in the meantime. When
+        // maxSubscribers is set this can hold a slot that no live player is using. We use
+        // ws.terminate() rather than a graceful close because a dead peer never completes the close
+        // handshake. The monitor stops itself on transport 'close', so no manual teardown is needed.
+        const keepaliveTimeout = this.config.playerKeepaliveTimeout || 0;
+        if (keepaliveTimeout > 0) {
+            const keepalive = new KeepaliveMonitor(newPlayer.protocol, keepaliveTimeout);
+            keepalive.onTimeout = () => {
+                Logger.info(
+                    `Player %s (%s) failed keepalive - terminating dead connection.`,
+                    newPlayer.playerId,
+                    request.socket.remoteAddress
+                );
+                ws.terminate();
+            };
+        }
 
         this.sendConfigMessage(newPlayer);
     }

--- a/SignallingWebServer/README.md
+++ b/SignallingWebServer/README.md
@@ -50,6 +50,8 @@ Options:
   --player_port <port>          Sets the listening port for player connections. (default: "80")
   --sfu_port <port>             Sets the listening port for SFU connections. (default: "8889")
   --max_players <number>        Sets the maximum number of subscribers per streamer. 0 = unlimited (default: "0")
+  --player_keepalive_timeout <milliseconds>
+                                Disconnect a player after this many milliseconds without a keepalive response. 0 = disabled (default: "30000")
   --serve                       Enables the webserver on player_port. (default: true)
   --http_root <path>            Sets the path for the webserver root. (default: "D:\\PixelStreamingInfrastructure\\SignallingWebServer\\www")
   --homepage <filename>         The default html file to serve on the web server. (default: "player.html")

--- a/SignallingWebServer/src/index.ts
+++ b/SignallingWebServer/src/index.ts
@@ -108,6 +108,11 @@ program
         'Sets the maximum number of subscribers per streamer. 0 = unlimited',
         config_file.max_players || '0'
     )
+    .option(
+        '--player_keepalive_timeout <milliseconds>',
+        'Disconnect a player after this many milliseconds without a keepalive response. 0 = disabled',
+        config_file.player_keepalive_timeout || '30000'
+    )
     .option('--serve', 'Enables the webserver on player_port.', config_file.serve || false)
     .option(
         '--http_root <path>',
@@ -270,7 +275,8 @@ const serverOpts: IServerConfig = {
     playerPort: options.player_port,
     sfuPort: options.sfu_port,
     peerOptions: options.peer_options,
-    maxSubscribers: options.max_players
+    maxSubscribers: options.max_players,
+    playerKeepaliveTimeout: Number(options.player_keepalive_timeout)
 };
 
 const shouldServerStart = options.serve || options.rest_api;


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
The signalling server never actively checks that a connected player is still alive. `KeepaliveMonitor` is only wired up on the client (browser to server); the server just replies to pings, it doesn't send its own. A player is only removed from the registry when its WebSocket fires `close`.

That's fine when a player disconnects cleanly, but if the socket dies *without* a close frame — laptop going to sleep, Wi-Fi dropping, a tunnel resetting, the tab being killed — the server never hears about it. The dead player stays in the registry and stays subscribed to its streamer until the OS TCP keepalive eventually reaps the socket, which on Windows defaults to around two hours (and `ws` doesn't enable it). 

With the default `--max_players 0` (unlimited) this is mostly harmless, which is probably why it hasn't come up. But as soon as you cap subscribers — `--max_players 1` for a single-viewer experience — that ghost holds the only slot, and every subsequent viewer is turned away with "Max players reached" until the server is restarted.

## Solution
Add the missing server-to-browser half of the keepalive. When a player connects, the server can now start a `KeepaliveMonitor` on that connection (the same class already used client-side); the browser answers these pings automatically via `handlePingMessage`, so no frontend change is needed. If a player misses the keepalive, the server calls `ws.terminate()` — a forceful close rather than a graceful one, because a dead peer never completes the close handshake — which fires `close` immediately and frees the slot.

It's controlled by a new `IServerConfig.playerKeepaliveTimeout` (milliseconds, `0` disables it). The signalling web server exposes it as `--player_keepalive_timeout`. I've defaulted it to 30000 (30s): reaping a genuinely dead connection is a correctness improvement that I think is worth having on by default, but it's fully tunable and can be turned off. A live browser always responds to the ping, so a real viewer is never evicted; only a connection that has gone completely silent is. The monitor stops itself on transport `close`, so there's no extra teardown.

## Documentation
`SignallingWebServer/README.md` is updated with the new option, and the config field and the logic both have explanatory comments.

## Test Plan and Compatibility
`npm run build` and `npm run lint` pass for `Common`, `Signalling` and `SignallingWebServer`. I tested by connecting a viewer and then dropping it ungracefully (killing the browser process / sleeping the machine / pulling Wi-Fi) — the server logs the keepalive failure and frees the slot within roughly one to two timeout intervals, and a new viewer can connect. The clean paths (normal disconnect, and a long idle-but-alive session) behave exactly as before and never evict a live viewer. Setting `--player_keepalive_timeout 0` restores the previous behaviour exactly.
