### PR TITLE
Fix/windows platform script defects

### DIFF
--- a/SignallingWebServer/platform_scripts/bash/common.sh
+++ b/SignallingWebServer/platform_scripts/bash/common.sh
@@ -310,7 +310,16 @@ function set_public_ip() {
 function setup_turn_stun() {
     if [[ -z "$TURN_SERVER" ]]; then
         TURN_SERVER="${PUBLIC_IP}:19303"
+    fi
+
+    # Defaults are applied independently of TURN_SERVER so that --turn-user and
+    # --turn-pass are honoured on their own, and so that supplying --turn alone
+    # still leaves credentials set for the launch guard below.
+    if [[ -z "$TURN_USER" ]]; then
         TURN_USER="PixelStreamingUser"
+    fi
+
+    if [[ -z "$TURN_PASS" ]]; then
         TURN_PASS="AnotherTURNintheroad"
     fi
 

--- a/SignallingWebServer/platform_scripts/cmd/README.txt
+++ b/SignallingWebServer/platform_scripts/cmd/README.txt
@@ -12,3 +12,8 @@ The following are provided as handy shortcuts but mostly leverage start.bat func
 Tips:
 
 - You can provide --help to start.bat to get a list of customizable arguments.
+- Values passed to these scripts cannot contain ^ or ! characters. cmd.exe
+  doubles a caret when the scripts hand their arguments to common.bat, and
+  strips an exclamation mark under delayed expansion, so a TURN password such
+  as "pass!word" arrives as "password" with no error. Choose credentials
+  without those two characters.

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -313,7 +313,7 @@ set TURN_PROCESS=turnserver.exe
 set TURN_REALM=PixelStreaming
 rem Credentials are expanded with ! rather than % so that characters cmd.exe
 rem treats as operators (&, |, ^, >) survive intact in a TURN password.
-set TURN_ARGS=-c ..\..\..\turnserver.conf --allowed-peer-ip=%LOCAL_IP% -p %TURN_PORT% -r %TURN_REALM% -X %PUBLIC_IP% -E %LOCAL_IP% -L %LOCAL_IP% --no-cli --no-tls --no-dtls --pidfile `"C:\coturn.pid`" -f -a -v -u !TURN_USER!:!TURN_PASS!
+set TURN_ARGS=-c ..\..\..\turnserver.conf --allowed-peer-ip=%LOCAL_IP% -p %TURN_PORT% -r %TURN_REALM% -X %PUBLIC_IP% -E %LOCAL_IP% -L %LOCAL_IP% --no-cli --no-tls --no-dtls --pidfile "%SCRIPT_DIR%coturn.pid" -f -a -v -u !TURN_USER!:!TURN_PASS!
 
 if "!START_TURN!"=="1" (
     IF NOT "!TURN_SERVER!"=="" (

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -34,7 +34,7 @@ echo        --build-wilbur      Force build of wilbur
 echo        --deps              Force reinstall of dependencies
 echo    Everything after -- is passed directly to the signalling server executable.
 IF exist "%SCRIPT_DIR%..\..\dist" (
-    pushd %SCRIPT_DIR%..\..
+    pushd "%SCRIPT_DIR%..\.."
     call %NPM% run start --- --help
     popd
 )
@@ -138,7 +138,7 @@ GOTO PostArgs
 exit /b
 
 :SetupNode
-pushd %SCRIPT_DIR%
+pushd "%SCRIPT_DIR%"
 SET NODE_NAME=node-%NODE_VERSION%-win-x64
 if exist node\ (
   echo Node directory found...skipping install.
@@ -166,7 +166,7 @@ popd
 
 if "%INSTALL_DEPS%"=="1" (
     echo Installing dependencies...
-    pushd %SCRIPT_DIR%..\..\..
+    pushd "%SCRIPT_DIR%..\..\.."
     call %NPM% install
     popd
 )
@@ -189,14 +189,14 @@ if NOT exist "%SCRIPT_DIR%..\..\..\Signalling\dist" (
 )
 
 IF "%BUILD_COMMON%"=="1" (
-    pushd %SCRIPT_DIR%..\..\..\Common
+    pushd "%SCRIPT_DIR%..\..\..\Common"
     echo Building common library
     call %NPM% run build:cjs
     popd
 )
 
 IF "%BUILD_SIGNALLING%"=="1" (
-    pushd %SCRIPT_DIR%..\..\..\Signalling
+    pushd "%SCRIPT_DIR%..\..\..\Signalling"
     echo Building signalling library
     call %NPM% run build:cjs
     popd
@@ -206,7 +206,7 @@ exit /b
 
 :SetupFrontend
 rem Start in the repo dir
-pushd %SCRIPT_DIR%..\..\..\
+pushd "%SCRIPT_DIR%..\..\.."
 
 IF "%FRONTEND_DIR%"=="" (
     set FRONTEND_DIR="%SCRIPT_DIR%..\..\www"
@@ -230,16 +230,16 @@ IF "%BUILD_FRONTEND%"=="1" (
     rem We could replace this all with a single npm script that does all this. we do have several build-all scripts already
     rem but this does give a good reference about the dependency chain for all of this.
     echo Building Typescript frontend...
-    pushd %CD%\Common
+    pushd "%CD%\Common"
     call %NPM% run build:esm
     popd
-    pushd %CD%\Frontend\library
+    pushd "%CD%\Frontend\library"
     call %NPM% run build:esm
     popd
-    pushd %CD%\Frontend\ui-library
+    pushd "%CD%\Frontend\ui-library"
     call %NPM% run build:esm
     popd
-    pushd %CD%\Frontend\implementations\typescript
+    pushd "%CD%\Frontend\implementations\typescript"
     rem Note: build:dev implicitly uses esm deps due to node16/bundler module resolution
     call %NPM% run build:dev
     popd
@@ -252,7 +252,7 @@ exit /b
 
 :SetupCoturn
 @Rem Look for CoTURN directory next to this script
-pushd %SCRIPT_DIR%
+pushd "%SCRIPT_DIR%"
 if exist coturn\ (
   echo CoTURN directory found...skipping install.
 ) else (
@@ -312,18 +312,23 @@ IF "%TURN_PORT%"=="" ( set TURN_PORT=3478 )
 set TURN_PROCESS=turnserver.exe
 set TURN_REALM=PixelStreaming
 rem Credentials are expanded with ! rather than % so that characters cmd.exe
-rem treats as operators (&, |, ^, >) survive intact in a TURN password.
-set TURN_ARGS=-c ..\..\..\turnserver.conf --allowed-peer-ip=%LOCAL_IP% -p %TURN_PORT% -r %TURN_REALM% -X %PUBLIC_IP% -E %LOCAL_IP% -L %LOCAL_IP% --no-cli --no-tls --no-dtls --pidfile "%SCRIPT_DIR%coturn.pid" -f -a -v -u !TURN_USER!:!TURN_PASS!
+rem treats as operators (&, |, ^, >) survive intact in a TURN password. The
+rem launch below must not use CALL for the same reason: CALL parses the line a
+rem second time, after ! expansion has already substituted the password, so an
+rem operator in the credential is re-read as syntax and the launch silently
+rem does nothing. turnserver.exe is an executable, and direct execution is
+rem synchronous without CALL.
+set TURN_ARGS=-c ..\..\..\turnserver.conf --allowed-peer-ip=%LOCAL_IP% -p %TURN_PORT% -r %TURN_REALM% -X %PUBLIC_IP% -E %LOCAL_IP% -L %LOCAL_IP% --no-cli --no-tls --no-dtls --pidfile "%SCRIPT_DIR%coturn\coturn.pid" -f -a -v -u !TURN_USER!:!TURN_PASS!
 
 if "!START_TURN!"=="1" (
     IF NOT "!TURN_SERVER!"=="" (
         IF NOT "!TURN_USER!"=="" (
             IF NOT "!TURN_PASS!"=="" (
-                pushd %SCRIPT_DIR%coturn\
+                pushd "%SCRIPT_DIR%coturn"
                 IF "%~1"=="bg" (
                     start "!TURN_PROCESS!" !TURN_PROCESS! !TURN_ARGS!
                 ) else (
-                    call "!TURN_PROCESS!" !TURN_ARGS!
+                    "!TURN_PROCESS!" !TURN_ARGS!
                 )
                 popd
             )
@@ -348,7 +353,7 @@ IF NOT exist "%SCRIPT_DIR%..\..\dist" (
 )
 
 IF "%BUILD_WILBUR%"=="1" (
-    pushd %SCRIPT_DIR%\..\..\
+    pushd "%SCRIPT_DIR%..\.."
     echo Building wilbur...
     call %NPM% run build
     popd
@@ -356,7 +361,7 @@ IF "%BUILD_WILBUR%"=="1" (
 exit /b
 
 :StartWilbur
-pushd %SCRIPT_DIR%\..\..\
+pushd "%SCRIPT_DIR%..\.."
 call %NPM% run start -- %SERVER_ARGS%
 exit /b
 

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -283,7 +283,14 @@ exit /b
 :SetupTurnStun
 IF "%TURN_SERVER%"=="" (
     set TURN_SERVER=%PUBLIC_IP%:19303
+)
+rem Defaults are applied independently of TURN_SERVER so that --turn-user and
+rem --turn-pass are honoured on their own, and so that supplying --turn alone
+rem still leaves credentials set for the launch guard below.
+IF "%TURN_USER%"=="" (
     set TURN_USER=PixelStreamingUser
+)
+IF "%TURN_PASS%"=="" (
     set TURN_PASS=AnotherTURNintheroad
 )
 IF "%STUN_SERVER%"=="" (

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -53,66 +53,71 @@ set TURN_PASS=
 set STUN_SERVER=
 set PUBLIC_IP=
 :arg_loop
-IF "%1"=="" GOTO LoopExit
-IF "%1"=="--" GOTO PostArgs
+IF "%~1"=="" GOTO LoopExit
+IF "%~1"=="--" GOTO PostArgs
 set HANDLED=0
-IF "%1"=="--help" (
+IF "%~1"=="--help" (
     CALL :Usage
     exit /b
 )
-IF "%1"=="--publicip" (
+IF "%~1"=="--publicip" (
     set HANDLED=1
-    set PUBLIC_IP=%2
+    set "PUBLIC_IP=%~2"
     SHIFT
 )
-IF "%1"=="--turn" (
+rem Values are assigned with the set "VAR=value" form, and compared with %~1
+rem rather than %1, so that cmd.exe does not re-parse operators (&, |, ^, >)
+rem appearing in a value. Both are required: SHIFT happens inside the matched
+rem block, so every comparison below it in the same pass is evaluated against
+rem the argument's value rather than the next flag.
+IF "%~1"=="--turn" (
     set HANDLED=1
-    set TURN_SERVER=%2
+    set "TURN_SERVER=%~2"
     SHIFT
 )
-IF "%1"=="--turn-user" (
+IF "%~1"=="--turn-user" (
     set HANDLED=1
-    set TURN_USER=%~2
+    set "TURN_USER=%~2"
     SHIFT
 )
-IF "%1"=="--turn-pass" (
+IF "%~1"=="--turn-pass" (
     set HANDLED=1
-    set TURN_PASS=%~2
+    set "TURN_PASS=%~2"
     SHIFT
 )
-if "%1"=="--start-turn" (
+if "%~1"=="--start-turn" (
     set HANDLED=1
     set START_TURN=1
 )
-IF "%1"=="--stun" (
+IF "%~1"=="--stun" (
     set HANDLED=1
-    set STUN_SERVER=%2
+    set "STUN_SERVER=%~2"
     SHIFT
 )
-IF "%1"=="--frontend-dir" (
+IF "%~1"=="--frontend-dir" (
     set HANDLED=1
-    set FRONTEND_DIR=%~2
+    set "FRONTEND_DIR=%~2"
     SHIFT
 )
-IF "%1"=="--build" (
+IF "%~1"=="--build" (
     set HANDLED=1
     set BUILD_FRONTEND=1
 )
-IF "%1"=="--rebuild" (
+IF "%~1"=="--rebuild" (
     set HANDLED=1
     set BUILD_LIBRARIES=1
     set BUILD_FRONTEND=1
     set BUILD_WILBUR=1
 )
-IF "%1"=="--build-libraries" (
+IF "%~1"=="--build-libraries" (
     set HANDLED=1
     set BUILD_LIBRARIES=1
 )
-IF "%1"=="--build-wilbur" (
+IF "%~1"=="--build-wilbur" (
     set HANDLED=1
     set BUILD_WILBUR=1
 )
-IF "%1"=="--deps" (
+IF "%~1"=="--deps" (
     set HANDLED=1
     set INSTALL_DEPS=1
 )
@@ -125,7 +130,7 @@ GOTO :arg_loop
 
 :PostArgs
 SHIFT
-IF "%1"=="" GOTO LoopExit
+IF "%~1"=="" GOTO LoopExit
 set SERVER_ARGS=%SERVER_ARGS% %1
 GOTO PostArgs
 
@@ -306,17 +311,19 @@ IF "%TURN_PORT%"=="" ( set TURN_PORT=3478 )
 
 set TURN_PROCESS=turnserver.exe
 set TURN_REALM=PixelStreaming
-set TURN_ARGS=-c ..\..\..\turnserver.conf --allowed-peer-ip=%LOCAL_IP% -p %TURN_PORT% -r %TURN_REALM% -X %PUBLIC_IP% -E %LOCAL_IP% -L %LOCAL_IP% --no-cli --no-tls --no-dtls --pidfile `"C:\coturn.pid`" -f -a -v -u %TURN_USER%:%TURN_PASS%
+rem Credentials are expanded with ! rather than % so that characters cmd.exe
+rem treats as operators (&, |, ^, >) survive intact in a TURN password.
+set TURN_ARGS=-c ..\..\..\turnserver.conf --allowed-peer-ip=%LOCAL_IP% -p %TURN_PORT% -r %TURN_REALM% -X %PUBLIC_IP% -E %LOCAL_IP% -L %LOCAL_IP% --no-cli --no-tls --no-dtls --pidfile `"C:\coturn.pid`" -f -a -v -u !TURN_USER!:!TURN_PASS!
 
-if "%START_TURN%"=="1" (
-    IF NOT "%TURN_SERVER%"=="" (
-        IF NOT "%TURN_USER%"=="" (
-            IF NOT "%TURN_PASS%"=="" (
+if "!START_TURN!"=="1" (
+    IF NOT "!TURN_SERVER!"=="" (
+        IF NOT "!TURN_USER!"=="" (
+            IF NOT "!TURN_PASS!"=="" (
                 pushd %SCRIPT_DIR%coturn\
-                IF "%1"=="bg" (
-                    start "%TURN_PROCESS%" %TURN_PROCESS% %TURN_ARGS%
+                IF "%~1"=="bg" (
+                    start "!TURN_PROCESS!" !TURN_PROCESS! !TURN_ARGS!
                 ) else (
-                    call "%TURN_PROCESS%" %TURN_ARGS%
+                    call "!TURN_PROCESS!" !TURN_ARGS!
                 )
                 popd
             )

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -72,11 +72,13 @@ IF "%1"=="--turn" (
 )
 IF "%1"=="--turn-user" (
     set HANDLED=1
-    set TURN_USER=1
+    set TURN_USER=%~2
+    SHIFT
 )
 IF "%1"=="--turn-pass" (
     set HANDLED=1
-    set TURN_PASS=1
+    set TURN_PASS=%~2
+    SHIFT
 )
 if "%1"=="--start-turn" (
     set HANDLED=1

--- a/SignallingWebServer/platform_scripts/cmd/setup.bat
+++ b/SignallingWebServer/platform_scripts/cmd/setup.bat
@@ -5,9 +5,11 @@ setlocal enabledelayedexpansion
 call :Init
 call :ParseArgs %*
 
-IF "%CONTINUE%"=="1" (
-	call :Setup
+IF errorlevel 1 (
+	exit /b 1
 )
+
+call :Setup
 
 goto :eof
 
@@ -18,4 +20,4 @@ goto :eof
 :SetupTurnStun
 :PrintConfig
 :StartWilbur
-%~dp0common.bat %*
+"%~dp0common.bat" %*

--- a/SignallingWebServer/platform_scripts/cmd/start_turn.bat
+++ b/SignallingWebServer/platform_scripts/cmd/start_turn.bat
@@ -6,13 +6,16 @@ title turnserver
 
 call :Init
 call :ParseArgs %*
-IF "%CONTINUE%"=="1" (
-	call :Setup
-	call :SetPublicIP
-	set DEFAULT_TURN=1
-	set START_TURN=1
-	call :SetupTurnStun
+
+IF errorlevel 1 (
+	exit /b 1
 )
+
+call :Setup
+call :SetPublicIP
+set DEFAULT_TURN=1
+set START_TURN=1
+call :SetupTurnStun
 
 goto :eof
 


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [x] Platform scripts
- [ ] SFU

## Problem statement:

Five defects in the startup scripts, four specific to Windows and one affecting both platforms. They are independent bugs that happen to cluster around TURN configuration and script entry points.

**1. `setup.bat` and `start_turn.bat` do nothing.** Both gate their entire body on `%CONTINUE%`, which is never assigned anywhere in the repository. `setup.bat` exits with no output, and `start_turn.bat` never launches a TURN server. This goes unnoticed because `start.bat` calls `:Setup` unconditionally, so the common path works and only the standalone entry points are affected.

**2. `--turn-user` and `--turn-pass` cannot be used on Windows.** Both assign the literal value `1` instead of their argument, and omit the `SHIFT` that every other value-taking flag performs. The credential is then consumed as an unrecognised argument and the script aborts with `Unknown arg`. There is no way to configure TURN credentials on Windows.

**3. TURN credential defaults are coupled to `--turn` (both platforms).** The default username and password are set inside the "TURN_SERVER is empty" branch, which fails in both directions:
- Passing `--turn-user`/`--turn-pass` *without* `--turn` leaves `TURN_SERVER`
  empty, so the branch runs and overwrites the supplied credentials with the
  public defaults.
- Passing `--turn` *alone* skips the branch, leaving both credentials empty. The
  launch guard requires them to be non-empty, so `turnserver` silently never
  starts.

**4. TURN passwords containing shell metacharacters break argument parsing on Windows.** A password containing `&`, `|` or `>` aborts the whole parse with `& was unexpected at this time`. `SHIFT` runs inside the matched block, so every comparison below it in the same pass is evaluated against the argument's *value* rather than the next flag; an unquoted `%1` then expands to something like `IF ""p@ss&word""=="--stun"`, whose unbalanced quoting lets cmd.exe re-parse the operator.

**5. The coturn `--pidfile` argument is malformed on Windows.** The value is wrapped in backticks — PowerShell escape syntax that has no meaning in a batch file — so coturn receives them as part of the path. The file is also placed at the root of `C:`, which is not writable without elevation.

## Solution

One commit per defect, each independently revertable:

- **`execute setup and start_turn bodies on Windows`** — replaces the dead
  `%CONTINUE%` guard with the `IF errorlevel 1` check `start.bat` already uses,
  so a bad argument still aborts but the normal path proceeds. Also quotes the
  `common.bat` dispatch path in `setup.bat` to match its sibling scripts (it was
  the only one unquoted, and would break under a path containing spaces).

- **`read --turn-user and --turn-pass values on Windows`** — assigns `%~2` and
  adds the missing `SHIFT`, matching how `--turn` and `--stun` are handled.

- **`apply TURN credential defaults independently of --turn`** — moves each
  default into its own emptiness check, in both `cmd/common.bat` and
  `bash/common.sh`, so the two scripts stay in step.

- **`preserve shell metacharacters in TURN credentials on Windows`** — compares
  with `%~1` instead of `%1` and assigns with the `set "VAR=value"` form.
  Credentials are expanded with `!` at the launch site for the same reason. The
  quoted-assignment form is applied to all value-taking flags, not just the TURN
  ones, because cmd.exe substitutes and parses *every* block in the loop
  including non-matching ones — a single unquoted assignment anywhere breaks the
  entire pass.

- **`correct coturn pidfile argument on Windows`** — removes the backticks and
  moves the pidfile beside the coturn install, a directory setup already writes
  to.

**One observable behaviour change**, following from defect 3: passing `--turn <server>` now leaves the default credentials in place instead of empty strings, so `peer_options` carries `PixelStreamingUser`/`AnotherTURNintheroad` rather than empty `username`/`credential` fields, and with `--start-turn` a local `turnserver` process now starts where the empty-credential launch guard previously blocked it. This is the intended correction — `--start-turn` is documented as "Will launch the turnserver process" — but it is a change for anyone passing `--turn` together with `--start-turn`. The default credential *values* are unchanged.

## Documentation

No documentation changes. The existing `--help` output in `common.bat` already describes `--turn-user` as "Sets the turn username when using a turn server" and `--turn-pass` likewise — this PR makes the implementation match the documented behaviour rather than changing it.

No changeset is included: these files live under `SignallingWebServer`, which is marked `"private": true` and is not published to NPM.

## Test Plan and Compatibility

There is no existing unit test harness for the platform scripts, so verification was manual against the real `common.bat` and `common.sh` rather than copies.

**Argument matrix** — every documented flag exercised individually, plus all 13 combined, plus the `--` passthrough, plus no arguments: all parse to the correct variables. `--help` and an unknown argument were checked on all five entry points (`setup`, `start`, `start_turn`, `start_with_stun`, `start_with_turn`)

**Regression on the specific fixes:**

| Case | Before | After |
| --- | --- | --- |
| `--turn-user alice --turn-pass s3cr3t` | `Unknown arg`, exit 1 | `alice` / `s3cr3t` |
| `--turn <server>` alone | credentials empty, TURN never started | defaults applied |
| no TURN arguments | defaults | defaults (unchanged) |
| password containing `&` | `& was unexpected at this time` | preserved intact |
| password containing `\|` `>` | parse aborted | preserved intact |
| `--frontend-dir "C:\Program Files\www"` | ok | ok |
| `setup.bat` | 0 lines of output | runs setup |

**End-to-end** — `start.bat --publicip 127.0.0.1 -- --player_port 8080` brings up a working server: HTTP 200 serving the player page, streamer listener on 8888, SFU listener on 8889, and `peer_options` correctly assembled with both STUN and TURN entries.

**common.sh** — `setup_turn_stun` verified across all four credential permutations (none / credentials only / `--turn` only / both).

 **Known limitations:**
- A value containing a caret (`^`) is doubled, because cmd.exe re-escapes carets through the `%*` re-parse in the label dispatch. Unchanged by this PR.
 - A value containing an exclamation mark (`!`) loses it: the entry points run under `setlocal enabledelayedexpansion`, so `set "TURN_PASS=%~2"` drops the `!` and `pass!word` silently becomes `password`. Unchanged by this PR. Both characters are now called out in `platform_scripts/cmd/README.txt`.
 - An `&` in an *unquoted* server argument after `--` (`-- a^&b`) breaks the script, because the bare `&` splits the `%*` dispatch line before argument parsing starts. Quote the value instead (`-- --http_root="C:\a&b\www"`) and it is preserved. 
- The first two affect every value-taking flag and predate this change. Fixing the caret means restructuring the label dispatch; fixing the `!` means turning delayed expansion off around argument parsing, which needs `endlocal` and would discard everything the parse just set.

**Affected branches:** `master`, `UE5.8`, `UE5.7`, `UE5.6`, `UE5.5`. `UE5.4` and earlier used PowerShell startup scripts and are not affected. Could a maintainer  please add auto-backport plus auto-backport-to-UE5.7, auto-backport-to-UE5.6,  and auto-backport-to-UE5.5?
