### PR TITLE
fix(scripts): read the value of --turn-user and --turn-pass on Windows

### DIFF
--- a/.changeset/turn-credential-args.md
+++ b/.changeset/turn-credential-args.md
@@ -1,0 +1,5 @@
+---
+'@epicgames-ps/wilbur': patch
+---
+
+Fix `--turn-user` and `--turn-pass` in the Windows launch scripts. Both set the literal value `1` instead of reading their argument, and neither shifts past it, so the value is then parsed as the next flag and the script exits with `Unknown arg`. The bash equivalents are correct, so this only affected `common.bat`.

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -72,11 +72,13 @@ IF "%1"=="--turn" (
 )
 IF "%1"=="--turn-user" (
     set HANDLED=1
-    set TURN_USER=1
+    set TURN_USER=%2
+    SHIFT
 )
 IF "%1"=="--turn-pass" (
     set HANDLED=1
-    set TURN_PASS=1
+    set TURN_PASS=%2
+    SHIFT
 )
 if "%1"=="--start-turn" (
     set HANDLED=1


### PR DESCRIPTION
## Relevant components:
- [ ] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [x] Platform scripts
- [ ] SFU

## Problem statement:
`--turn-user` and `--turn-pass` cannot be used on Windows. In `common.bat`:

```bat
IF "%1"=="--turn-user" (
    set HANDLED=1
    set TURN_USER=1
)
```

Both set the literal string `1` rather than reading `%2`, and neither `SHIFT`s past the value they were given. So the value lands back in `%1` on the next iteration, matches no known flag, and falls through to `echo Unknown arg %1` â€” the script prints usage and exits 1. There is no way to pass TURN credentials through the documented flags at all; the only route is `--peer_options`/`--peer_options_file`, which is not what the help text says.

`common.sh` gets both right (`--turn-user ) TURN_USER="$2"; shift 2;;`), so this is a defect in the Windows port rather than a difference in intent between the two scripts.

## Solution
Read `%2` and `SHIFT`, matching the `--turn` and `--publicip` options immediately above, which are already written that way.

## Documentation
No documentation change: the existing help text (`--turn-user         Sets the turn username when using a turn server.`) already describes the behaviour this restores.

Two things I ran into that are **not** regressions from this change, but which only become reachable now that the flags work, so they are worth knowing:

- `SetupTurnStun` overwrites `TURN_USER`/`TURN_PASS` with `PixelStreamingUser`/`AnotherTURNintheroad` when no `--turn` is supplied. `common.sh` does the same, so I have left it alone.
- A value containing `&`, a space or `!` still breaks, because it lands in `%1` and then breaks the following `IF "%1"=="..."` comparisons. This is structural to the argument loop and affects `--turn` and `--publicip` on master identically; `set "VAR=%~2"` does not fix it.

## Test Plan and Compatibility
`start.bat --turn 1.2.3.4:3478 --turn-user someuser --turn-pass somepass` previously exited with `Unknown arg someuser`; it now starts, and the credentials reach both `PEER_OPTIONS` (as `"username":"someuser","credential":"somepass"`) and `TURN_ARGS` (as `-u someuser:somepass`). Launching with no TURN flags is unchanged. Nothing outside the argument parser is touched, and the bash scripts are not modified.
