### PR TITLE
fix(signalling): do not crash when a forced subscription is declined

### DIFF
--- a/.changeset/player-forced-subscribe-crash.md
+++ b/.changeset/player-forced-subscribe-crash.md
@@ -1,5 +1,6 @@
 ---
 '@epicgames-ps/lib-pixelstreamingsignalling-ue5.8': patch
+'@epicgames-ps/wilbur': patch
 ---
 
 Stop an unsubscribed player from crashing the signalling server. When a player sends a message without being subscribed, `sendToStreamer` force-subscribes it to the first available streamer and then forwards through `this.subscribedStreamer!`. `subscribe()` can decline — most commonly because `maxSubscribers` is already reached — and reports that only by leaving `subscribedStreamer` unset, so the non-null assertions throw a TypeError out of a websocket message handler and take the process down, disconnecting every other player. It now checks the subscription took, and disconnects just that player if it did not.

--- a/.changeset/player-forced-subscribe-crash.md
+++ b/.changeset/player-forced-subscribe-crash.md
@@ -1,0 +1,5 @@
+---
+'@epicgames-ps/lib-pixelstreamingsignalling-ue5.8': patch
+---
+
+Stop an unsubscribed player from crashing the signalling server. When a player sends a message without being subscribed, `sendToStreamer` force-subscribes it to the first available streamer and then forwards through `this.subscribedStreamer!`. `subscribe()` can decline — most commonly because `maxSubscribers` is already reached — and reports that only by leaving `subscribedStreamer` unset, so the non-null assertions throw a TypeError out of a websocket message handler and take the process down, disconnecting every other player. It now checks the subscription took, and disconnects just that player if it did not.

--- a/Signalling/src/PlayerConnection.ts
+++ b/Signalling/src/PlayerConnection.ts
@@ -142,12 +142,22 @@ export class PlayerConnection implements IPlayer, LogUtils.IMessageLogger {
             } else {
                 Logger.warn(`Subscribing to ${streamerId}`);
                 this.subscribe(streamerId);
+                // subscribe() declines silently, most often because maxSubscribers is reached, and
+                // says so only by leaving subscribedStreamer unset. Forwarding anyway dereferences
+                // null, which surfaces as an uncaughtException and exits the process.
+                if (!this.subscribedStreamer) {
+                    Logger.error(
+                        `Player ${this.playerId} could not be subscribed to ${streamerId}. Disconnecting.`
+                    );
+                    this.disconnect();
+                    return;
+                }
             }
         }
 
         message.playerId = this.playerId;
-        LogUtils.logForward(this, this.subscribedStreamer!, message);
-        this.subscribedStreamer!.protocol.sendMessage(message);
+        LogUtils.logForward(this, this.subscribedStreamer, message);
+        this.subscribedStreamer.protocol.sendMessage(message);
     }
 
     private subscribe(streamerId: string) {


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
A single player can take the whole signalling server down and disconnect everyone else with it.

When a player sends a message while not subscribed, `PlayerConnection.sendToStreamer()` force-subscribes it to the first available streamer and then forwards through `this.subscribedStreamer!`. But `subscribe()` can decline â€” most often because `maxSubscribers` is reached â€” and it signals that only by leaving the field unset, so the non-null assertions dereference null.

That doesn't propagate through `ws` as you might expect: `Common`'s `EventEmitter` is built on `EventTarget`, which catches each listener's throw and re-raises it on `process.nextTick`. Nothing installs an `uncaughtException` handler anywhere in the project, so the process exits.

Easiest to hit at `--max_players 1`, where the second player to send anything is over the limit by definition, but it applies at any limit. The branch directly above already handles the sibling case correctly â€” when there's no streamer at all, it logs and disconnects that one player. Only the declined-subscription path is missing.

## Solution
Check the forced subscription actually took, and if not, disconnect that player and return â€” the same treatment the no-streamer branch gives. With the check in place the assertions aren't needed, so they're dropped rather than left implying an invariant the code doesn't have.

Two things I decided rather than assumed. Disconnecting rather than dropping the message matches the branch above, and a player that reaches here is sending into a subscription it doesn't have, so dropping silently leaves it repeating that forever â€” though an *explicit* `subscribe` declined for `maxSubscribers` only gets `subscribeFailed` and stays connected, so this is harsher than that path. And `subscribe()` still returns `void`: reporting failure by leaving a field unset is the underlying shape problem, but a `boolean` return doesn't narrow `subscribedStreamer` for TypeScript, so the caller ends up checking twice anyway. Happy to do that properly as a follow-up across both call sites.

## Documentation
None needed â€” this restores the behaviour the surrounding code already demonstrates. There's a comment at the check, since the failure mode isn't obvious from `subscribe()`'s signature.

## Test Plan and Compatibility
Reproduced against a build of this branch's parent: `maxSubscribers: 1`, one player subscribed, then a second player sending an offer while unsubscribed. The server exits with `TypeError: Cannot read properties of null (reading 'getReadableIdentifier')` and the first player's stream goes down with it. With the fix the second player gets `subscribeFailed`, is disconnected, and the server stays up.

`npm run build` and `npm run lint` pass for `Signalling`. No unit test: there's no suite in that package to hang one on, and adding a runner felt out of scope for a two-line fix â€” happy to add both if you'd rather. Behaviour is unchanged on every path where the subscription succeeds, which is the normal case.
