### PR TITLE
[UE5.7] chore(deps-dev): bump js-yaml (#959)

### DIFF
--- a/Extras/eslint/plugin-check-copyright/package-lock.json
+++ b/Extras/eslint/plugin-check-copyright/package-lock.json
@@ -754,9 +754,9 @@
             "license": "ISC"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.7`:
 - [chore(deps-dev): bump js-yaml (#959)](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/959)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)