### PR TITLE
[UE5.7] fix(signalling): do not crash when a forced subscription is declined (#958)

### DIFF
--- a/.changeset/player-forced-subscribe-crash.md
+++ b/.changeset/player-forced-subscribe-crash.md
@@ -1,0 +1,6 @@
+---
+'@epicgames-ps/lib-pixelstreamingsignalling-ue5.8': patch
+'@epicgames-ps/wilbur': patch
+---
+
+Stop an unsubscribed player from crashing the signalling server. When a player sends a message without being subscribed, `sendToStreamer` force-subscribes it to the first available streamer and then forwards through `this.subscribedStreamer!`. `subscribe()` can decline — most commonly because `maxSubscribers` is already reached — and reports that only by leaving `subscribedStreamer` unset, so the non-null assertions throw a TypeError out of a websocket message handler and take the process down, disconnecting every other player. It now checks the subscription took, and disconnects just that player if it did not.

--- a/Signalling/src/PlayerConnection.ts
+++ b/Signalling/src/PlayerConnection.ts
@@ -142,12 +142,22 @@ export class PlayerConnection implements IPlayer, LogUtils.IMessageLogger {
             } else {
                 Logger.warn(`Subscribing to ${streamerId}`);
                 this.subscribe(streamerId);
+                // subscribe() declines silently, most often because maxSubscribers is reached, and
+                // says so only by leaving subscribedStreamer unset. Forwarding anyway dereferences
+                // null, which surfaces as an uncaughtException and exits the process.
+                if (!this.subscribedStreamer) {
+                    Logger.error(
+                        `Player ${this.playerId} could not be subscribed to ${streamerId}. Disconnecting.`
+                    );
+                    this.disconnect();
+                    return;
+                }
             }
         }
 
         message.playerId = this.playerId;
-        LogUtils.logForward(this, this.subscribedStreamer!, message);
-        this.subscribedStreamer!.protocol.sendMessage(message);
+        LogUtils.logForward(this, this.subscribedStreamer, message);
+        this.subscribedStreamer.protocol.sendMessage(message);
     }
 
     private subscribe(streamerId: string) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `UE5.7`:
 - [fix(signalling): do not crash when a forced subscription is declined (#958)](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/958)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)