### PR TITLE
[UE5.6] Add optional server-side player keepalive to reap dead connections (#912)

### DIFF
--- a/.changeset/server-player-keepalive.md
+++ b/.changeset/server-player-keepalive.md
@@ -1,0 +1,6 @@
+---
+'@epicgames-ps/lib-pixelstreamingsignalling-ue5.7': patch
+'@epicgames-ps/wilbur': patch
+---
+
+Add an optional server-side keepalive that disconnects players whose connection has died without a clean close. Previously `KeepaliveMonitor` was only used on the client, so a player whose socket dropped silently (sleeping laptop, lost Wi-Fi, killed tab) stayed subscribed until the OS TCP keepalive reaped it, which could hold a `maxSubscribers` slot in the meantime. The new `IServerConfig.playerKeepaliveTimeout` controls this; the signalling server exposes it as `--player_keepalive_timeout <milliseconds>` (default 30000, 0 disables).

--- a/Signalling/src/SignallingServer.ts
+++ b/Signalling/src/SignallingServer.ts
@@ -8,7 +8,12 @@ import { SFUConnection } from './SFUConnection';
 import { Logger } from './Logger';
 import { StreamerRegistry } from './StreamerRegistry';
 import { PlayerRegistry } from './PlayerRegistry';
-import { Messages, MessageHelpers, SignallingProtocol } from '@epicgames-ps/lib-pixelstreamingcommon-ue5.6';
+import {
+    Messages,
+    MessageHelpers,
+    SignallingProtocol,
+    KeepaliveMonitor
+} from '@epicgames-ps/lib-pixelstreamingcommon-ue5.6';
 import { stringify } from './Utils';
 
 /**
@@ -45,6 +50,10 @@ export interface IServerConfig {
 
     // Max number of players per streamer.
     maxSubscribers?: number;
+
+    // Idle timeout in milliseconds after which a player that has stopped responding to keepalive
+    // pings is forcibly disconnected. 0 (the default) disables the check.
+    playerKeepaliveTimeout?: number;
 }
 
 export type ProtocolConfig = {
@@ -158,6 +167,25 @@ export class SignallingServer {
             this.playerRegistry.remove(newPlayer);
             Logger.info(`Player %s (%s) disconnected.`, newPlayer.playerId, request.socket.remoteAddress);
         });
+
+        // Optionally monitor the player connection for liveness. A player whose socket dies without
+        // a clean close frame (sleeping laptop, dropped Wi-Fi, killed tab) is otherwise only removed
+        // once the OS TCP keepalive eventually reaps it, leaving it subscribed in the meantime. When
+        // maxSubscribers is set this can hold a slot that no live player is using. We use
+        // ws.terminate() rather than a graceful close because a dead peer never completes the close
+        // handshake. The monitor stops itself on transport 'close', so no manual teardown is needed.
+        const keepaliveTimeout = this.config.playerKeepaliveTimeout || 0;
+        if (keepaliveTimeout > 0) {
+            const keepalive = new KeepaliveMonitor(newPlayer.protocol, keepaliveTimeout);
+            keepalive.onTimeout = () => {
+                Logger.info(
+                    `Player %s (%s) failed keepalive - terminating dead connection.`,
+                    newPlayer.playerId,
+                    request.socket.remoteAddress
+                );
+                ws.terminate();
+            };
+        }
 
         this.sendConfigMessage(newPlayer);
     }

--- a/SignallingWebServer/README.md
+++ b/SignallingWebServer/README.md
@@ -54,6 +54,8 @@ Options:
   --player_port <port>          Sets the listening port for player connections. (default: "80")
   --sfu_port <port>             Sets the listening port for SFU connections. (default: "8889")
   --max_players <number>        Sets the maximum number of subscribers per streamer. 0 = unlimited (default: "0")
+  --player_keepalive_timeout <milliseconds>
+                                Disconnect a player after this many milliseconds without a keepalive response. 0 = disabled (default: "30000")
   --serve                       Enables the webserver on player_port. (default: true)
   --http_root <path>            Sets the path for the webserver root. (default: "D:\\PixelStreamingInfrastructure\\SignallingWebServer\\www")
   --homepage <filename>         The default html file to serve on the web server. (default: "player.html")

--- a/SignallingWebServer/src/index.ts
+++ b/SignallingWebServer/src/index.ts
@@ -108,6 +108,11 @@ program
         'Sets the maximum number of subscribers per streamer. 0 = unlimited',
         config_file.max_players || '0'
     )
+    .option(
+        '--player_keepalive_timeout <milliseconds>',
+        'Disconnect a player after this many milliseconds without a keepalive response. 0 = disabled',
+        config_file.player_keepalive_timeout || '30000'
+    )
     .option('--serve', 'Enables the webserver on player_port.', config_file.serve || false)
     .option(
         '--http_root <path>',
@@ -270,7 +275,8 @@ const serverOpts: IServerConfig = {
     playerPort: options.player_port,
     sfuPort: options.sfu_port,
     peerOptions: options.peer_options,
-    maxSubscribers: options.max_players
+    maxSubscribers: options.max_players,
+    playerKeepaliveTimeout: Number(options.player_keepalive_timeout)
 };
 
 const shouldServerStart = options.serve || options.rest_api;


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Manual backport of [#912](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/912) from `master` to `UE5.6`. The automatic backport never ran for it, so UE5.6 and UE5.7 are the only live branches missing it — UE5.8 shares master's history and already carries `111007d3`.

Without it, a player whose socket dies without a clean close (sleeping laptop, dropped Wi-Fi, killed tab) stays subscribed on UE5.6 until the OS TCP keepalive eventually reaps it, holding a `maxSubscribers` slot in the meantime.

This is also the first of two prerequisites for backporting #956 (per-connection TURN credentials) to UE5.6; the second is #921, in the companion PR below.

## Solution
Cherry-pick of `111007d3` with one conflict resolved by hand.

- `Signalling/src/SignallingServer.ts` — the conflict, and it is only the package suffix. #912 rewrote the single-line `@epicgames-ps/lib-pixelstreamingcommon-*` import into a multi-line one to add `KeepaliveMonitor`, and the incoming version named `-ue5.7`. Resolved by taking the incoming import and correcting the suffix to `-ue5.6`. Everything else in the file applied clean.
- `SignallingWebServer/src/index.ts`, `SignallingWebServer/README.md`, `.changeset/server-player-keepalive.md` — applied clean. They add `--player_keepalive_timeout <milliseconds>` and wire it to `IServerConfig.playerKeepaliveTimeout`.

The changeset still names `-ue5.7`; `.github/scripts/version-with-normalized-suffixes.sh` rewrites that at release time, so it is left as the cherry-pick produced it.

## Documentation
`SignallingWebServer/README.md` gains the `--player_keepalive_timeout` entry, as on `master`.

## Test Plan and Compatibility
`npm run build` and `npm run lint` pass in `Common`, `Signalling` and `SignallingWebServer` on Node 22.14.0.

Confirmed `KeepaliveMonitor` is exported from this branch's `Common` (`Common/src/pixelstreamingcommon.ts`) so the corrected import resolves — the class was already there, just unused by the signalling server.

Confirmed no `-ue5.7` references remain under `Signalling/src` or `SignallingWebServer/src` after the resolution.

**Behaviour change worth noting:** the flag defaults to `30000`, and the monitor is active whenever the value is above zero, so after this merges UE5.6 will disconnect players that stop answering keepalives — matching `master` and UE5.8. Set `--player_keepalive_timeout 0` to restore the current UE5.6 behaviour.
