### PR TITLE
[UE5.6] Add hooks for consumer-supplied connection auth (#921)

### DIFF
--- a/.changeset/streamer-id-authorizer-hook.md
+++ b/.changeset/streamer-id-authorizer-hook.md
@@ -1,0 +1,5 @@
+---
+'@epicgames-ps/lib-pixelstreamingsignalling-ue5.7': minor
+---
+
+Add extension points so consumers can plug in their own authentication and authorization without the library shipping an auth scheme. Connections now expose the HTTP upgrade `request` (`IStreamer.request` / `IPlayer.request`) so identity attached during a `verifyClient` check survives to later decisions, and `IServerConfig.authorizeStreamerId` lets a consumer authorize, override (e.g. namespace per tenant), or reject the id a streamer registers as — the seam for preventing streamer-id squatting. Default behaviour is unchanged when these are not supplied. See `Docs/Security-Guidelines.md`.

--- a/Docs/Security-Guidelines.md
+++ b/Docs/Security-Guidelines.md
@@ -18,3 +18,55 @@ Please note that implementing the following suggestions may introduce additional
 6. **Separate TURN and Signalling Servers:** It is recommended to avoid colocating the TURN and signalling servers with the UE instance on the same IP or virtual machine (VM). This enables you to configure separate ingress/egress security policies for each server, allowing flexibility in defining the desired level of strictness or looseness. For example, the TURN server can have more relaxed policies while the UE instance can have stricter ones.
 
 By following these tips, you can enhance the security of your Pixel Streaming setup and mitigate potential risks.
+
+## Authenticating and authorizing connections
+
+The signalling server **intentionally ships no authentication**. The streamer, player and SFU ports accept any connection, and any deployment is expected to bring its own authentication and authorization appropriate to its environment. In particular, the streamer port is designed to sit on a trusted/private network and should never be exposed directly to the internet without a front door of your own.
+
+To make it practical to add your own auth without forking, the `Signalling` library exposes a few seams. None of these provide credentials or a login flow — they are hooks where *your* policy plugs in.
+
+### Authenticating at the WebSocket upgrade
+
+The per-listener options (`streamerWsOptions`, `playerWsOptions`, `sfuWsOptions` on `IServerConfig`) are passed straight through to the underlying [`ws`](https://github.com/websockets/ws) server, so you can supply a `verifyClient` callback to accept or reject a connection during the HTTP upgrade — **before** the server sends its config message (which includes peer/TURN options). This is the recommended place to authenticate, because it runs before any data is sent to the peer.
+
+```ts
+const server = new SignallingServer({
+    streamerPort: 8888,
+    playerPort: 80,
+    peerOptions: { /* ... */ },
+    streamerWsOptions: {
+        verifyClient: (info, cb) => {
+            const ok = isValidToken(info.req); // your check: header, query string, mTLS, etc.
+            if (ok) {
+                // Stamp the authenticated identity onto the request so it can be recovered later.
+                (info.req as any).identity = resolveIdentity(info.req);
+            }
+            cb(ok, 401, 'unauthorized');
+        }
+    }
+});
+```
+
+### Recovering the authenticated identity
+
+Each connection exposes the HTTP upgrade `request` that opened it (`streamer.request` / `player.request`). Anything your `verifyClient` (or other front door) attached to the request is available there, so later authorization decisions can use the identity established at connect time.
+
+### Authorizing the streamer id (preventing id squatting)
+
+By default, when a streamer identifies itself the registry accepts the requested id and appends a numeric suffix if that id is already taken. On a shared, unauthenticated streamer port this allows *id squatting*: a connection can claim an id before the legitimate streamer connects, and the legitimate streamer is then silently renamed.
+
+`IServerConfig.authorizeStreamerId` lets you own that decision. It is called with the requesting `streamer` (use `streamer.request` for identity), the `requestedId`, the `sanitizedId` the registry would otherwise commit, and whether the requested id `collided`. Return the id to commit (the sanitized id to accept the default, or any other unique id to override — e.g. to namespace per tenant), or `null` to reject the streamer and disconnect it.
+
+```ts
+const server = new SignallingServer({
+    // ...
+    authorizeStreamerId: ({ streamer, requestedId }) => {
+        const identity = (streamer.request as any)?.identity;
+        if (!identity) return null;                 // reject unauthenticated streamers
+        if (!identity.mayUseId(requestedId)) return null; // enforce ownership
+        return `${identity.tenant}:${requestedId}`; // namespace so tenants can't collide
+    }
+});
+```
+
+These hooks are deliberately policy-free: the library gives you the connection, its request, and the id it is asking for — what counts as a valid token or a permitted id is entirely up to your deployment.

--- a/Signalling/src/PlayerConnection.ts
+++ b/Signalling/src/PlayerConnection.ts
@@ -1,4 +1,5 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
+import type { IncomingMessage } from 'http';
 import WebSocket from 'ws';
 import {
     ITransport,
@@ -36,6 +37,8 @@ export class PlayerConnection implements IPlayer, LogUtils.IMessageLogger {
     subscribedStreamer: IStreamer | null;
     // A descriptive string describing the remote address of this connection.
     remoteAddress?: string;
+    // The HTTP upgrade request that opened this connection, if available.
+    request?: IncomingMessage;
 
     private server: SignallingServer;
     private streamerIdChangeListener: (newId: string) => void;
@@ -47,14 +50,16 @@ export class PlayerConnection implements IPlayer, LogUtils.IMessageLogger {
      * @param server - The signalling server object that spawned this player.
      * @param ws - The websocket coupled to this player connection.
      * @param remoteAddress - The remote address of this connection. Only used as display.
+     * @param request - The HTTP upgrade request that opened this connection, if available.
      */
-    constructor(server: SignallingServer, ws: WebSocket, remoteAddress?: string) {
+    constructor(server: SignallingServer, ws: WebSocket, remoteAddress?: string, request?: IncomingMessage) {
         this.server = server;
         this.playerId = '';
         this.subscribedStreamer = null;
         this.transport = new WebSocketTransportNJS(ws);
         this.protocol = new SignallingProtocol(this.transport);
         this.remoteAddress = remoteAddress;
+        this.request = request;
 
         this.transport.on('error', this.onTransportError.bind(this));
         this.transport.on('close', this.onTransportClose.bind(this));

--- a/Signalling/src/PlayerRegistry.ts
+++ b/Signalling/src/PlayerRegistry.ts
@@ -1,4 +1,5 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
+import type { IncomingMessage } from 'http';
 import { SignallingProtocol, BaseMessage, EventEmitter } from '@epicgames-ps/lib-pixelstreamingcommon-ue5.6';
 import { Logger } from './Logger';
 import { IMessageLogger } from './LoggingUtils';
@@ -12,6 +13,10 @@ export interface IPlayer extends IMessageLogger {
     playerId: string;
     protocol: SignallingProtocol;
     subscribedStreamer: IStreamer | null;
+    // The HTTP upgrade request that opened this connection, if available. Lets a consumer-supplied
+    // verifyClient (or other front door) attach an authenticated identity to the request and
+    // recover it here. The signalling server itself does not read this.
+    request?: IncomingMessage;
 
     sendMessage(message: BaseMessage): void;
     getPlayerInfo(): IPlayerInfo;

--- a/Signalling/src/SFUConnection.ts
+++ b/Signalling/src/SFUConnection.ts
@@ -1,4 +1,5 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
+import type { IncomingMessage } from 'http';
 import WebSocket from 'ws';
 import {
     ITransport,
@@ -45,6 +46,8 @@ export class SFUConnection extends EventEmitter implements IPlayer, IStreamer, L
     subscribedStreamer: IStreamer | null;
     // A descriptive string describing the remote address of this connection.
     remoteAddress?: string;
+    // The HTTP upgrade request that opened this connection, if available.
+    request?: IncomingMessage;
     // The max number of subscribed players at a time. A value of 0 means there is no limit (this the default).
     maxSubscribers: number;
     // A list of all the current subscribed players.
@@ -60,8 +63,9 @@ export class SFUConnection extends EventEmitter implements IPlayer, IStreamer, L
      * @param server - The signalling server object that spawned this sfu.
      * @param ws - The websocket coupled to this sfu connection.
      * @param remoteAddress - The remote address of this connection. Only used as display.
+     * @param request - The HTTP upgrade request that opened this connection, if available.
      */
-    constructor(server: SignallingServer, ws: WebSocket, remoteAddress?: string) {
+    constructor(server: SignallingServer, ws: WebSocket, remoteAddress?: string, request?: IncomingMessage) {
         super();
 
         this.server = server;
@@ -71,6 +75,7 @@ export class SFUConnection extends EventEmitter implements IPlayer, IStreamer, L
         this.streamerId = '';
         this.streaming = false;
         this.remoteAddress = remoteAddress;
+        this.request = request;
         this.subscribedStreamer = null;
         this.maxSubscribers = 0;
         this.subscribers = new Set();

--- a/Signalling/src/SignallingServer.ts
+++ b/Signalling/src/SignallingServer.ts
@@ -6,7 +6,7 @@ import { StreamerConnection } from './StreamerConnection';
 import { PlayerConnection } from './PlayerConnection';
 import { SFUConnection } from './SFUConnection';
 import { Logger } from './Logger';
-import { StreamerRegistry } from './StreamerRegistry';
+import { StreamerRegistry, StreamerIdAuthorizer } from './StreamerRegistry';
 import { PlayerRegistry } from './PlayerRegistry';
 import {
     Messages,
@@ -54,6 +54,12 @@ export interface IServerConfig {
     // Idle timeout in milliseconds after which a player that has stopped responding to keepalive
     // pings is forcibly disconnected. 0 (the default) disables the check.
     playerKeepaliveTimeout?: number;
+
+    // Optional hook to authorize (or override) the id a streamer registers as when it identifies
+    // itself. This is the seam for consumer-supplied anti-squatting / ownership policy; the project
+    // ships no authentication of its own. See StreamerIdAuthorizer. When omitted, the default
+    // behaviour is unchanged (requested id accepted, numeric suffix appended on collision).
+    authorizeStreamerId?: StreamerIdAuthorizer;
 }
 
 export type ProtocolConfig = {
@@ -81,7 +87,7 @@ export class SignallingServer {
         Logger.debug('Started SignallingServer with config: %s', stringify(config));
 
         this.config = config;
-        this.streamerRegistry = new StreamerRegistry();
+        this.streamerRegistry = new StreamerRegistry(config.authorizeStreamerId);
         this.playerRegistry = new PlayerRegistry();
         this.protocolConfig = {
             protocolVersion: SignallingProtocol.SIGNALLING_VERSION,
@@ -139,7 +145,7 @@ export class SignallingServer {
     private onStreamerConnected(ws: wslib.WebSocket, request: http.IncomingMessage) {
         Logger.info(`New streamer connection: %s`, request.socket.remoteAddress);
 
-        const newStreamer = new StreamerConnection(this, ws, request.socket.remoteAddress);
+        const newStreamer = new StreamerConnection(this, ws, request.socket.remoteAddress, request);
         newStreamer.maxSubscribers = this.config.maxSubscribers || 0;
 
         // add it to the registry and when the transport closes, remove it.
@@ -159,7 +165,7 @@ export class SignallingServer {
     private onPlayerConnected(ws: wslib.WebSocket, request: http.IncomingMessage) {
         Logger.info(`New player connection: %s (%s)`, request.socket.remoteAddress, request.url);
 
-        const newPlayer = new PlayerConnection(this, ws, request.socket.remoteAddress);
+        const newPlayer = new PlayerConnection(this, ws, request.socket.remoteAddress, request);
 
         // add it to the registry and when the transport closes, remove it
         this.playerRegistry.add(newPlayer);
@@ -192,7 +198,7 @@ export class SignallingServer {
 
     private onSFUConnected(ws: wslib.WebSocket, request: http.IncomingMessage) {
         Logger.info(`New SFU connection: %s`, request.socket.remoteAddress);
-        const newSFU = new SFUConnection(this, ws, request.socket.remoteAddress);
+        const newSFU = new SFUConnection(this, ws, request.socket.remoteAddress, request);
 
         // SFU acts as both a streamer and player
         this.streamerRegistry.add(newSFU);

--- a/Signalling/src/StreamerConnection.ts
+++ b/Signalling/src/StreamerConnection.ts
@@ -1,4 +1,5 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
+import type { IncomingMessage } from 'http';
 import WebSocket from 'ws';
 import {
     ITransport,
@@ -38,6 +39,8 @@ export class StreamerConnection extends EventEmitter implements IStreamer, LogUt
     streaming: boolean;
     // A descriptive string describing the remote address of this connection.
     remoteAddress?: string;
+    // The HTTP upgrade request that opened this connection, if available.
+    request?: IncomingMessage;
     // The max number of subscribed players at a time.
     maxSubscribers: number;
     // A list of all the current subscribed players.
@@ -51,8 +54,9 @@ export class StreamerConnection extends EventEmitter implements IStreamer, LogUt
      * @param server - The signalling server object that spawned this streamer.
      * @param ws - The websocket coupled to this streamer connection.
      * @param remoteAddress - The remote address of this connection. Only used as display.
+     * @param request - The HTTP upgrade request that opened this connection, if available.
      */
-    constructor(server: SignallingServer, ws: WebSocket, remoteAddress?: string) {
+    constructor(server: SignallingServer, ws: WebSocket, remoteAddress?: string, request?: IncomingMessage) {
         super();
 
         this.server = server;
@@ -61,6 +65,7 @@ export class StreamerConnection extends EventEmitter implements IStreamer, LogUt
         this.protocol = new SignallingProtocol(this.transport);
         this.streaming = false;
         this.remoteAddress = remoteAddress;
+        this.request = request;
         this.maxSubscribers = 0;
         this.subscribers = new Set();
 

--- a/Signalling/src/StreamerRegistry.ts
+++ b/Signalling/src/StreamerRegistry.ts
@@ -7,6 +7,7 @@ import {
     BaseMessage,
     EventEmitter
 } from '@epicgames-ps/lib-pixelstreamingcommon-ue5.6';
+import type { IncomingMessage } from 'http';
 import { Logger } from './Logger';
 import { IMessageLogger } from './LoggingUtils';
 import { IPlayerInfo } from './PlayerRegistry';
@@ -22,10 +23,42 @@ export interface IStreamer extends EventEmitter, IMessageLogger {
     streaming: boolean;
     maxSubscribers: number;
     subscribers: Set<string>;
+    // The HTTP upgrade request that opened this connection, if available. The signalling server
+    // itself does not read this, but it lets a consumer-supplied verifyClient (or other front door)
+    // attach an authenticated identity to the request and recover it here for authorization
+    // decisions. The project intentionally ships no authentication of its own.
+    request?: IncomingMessage;
 
     sendMessage(message: BaseMessage): void;
     getStreamerInfo(): IStreamerInfo;
 }
+
+/**
+ * The details of a streamer's request to be known by a given id, passed to a
+ * {@link StreamerIdAuthorizer} so a consumer can decide whether to allow it.
+ */
+export interface IStreamerIdAuthRequest {
+    // The streamer connection requesting the id. Use `streamer.request` to recover any identity a
+    // consumer attached at connection time.
+    streamer: IStreamer;
+    // The raw id the streamer asked to be known by (the value it sent in its endpointId message).
+    requestedId: string;
+    // The unique id the registry would assign by default (the requested id, with a numeric suffix
+    // appended if it collided with an existing streamer).
+    sanitizedId: string;
+    // True when the requested id was already taken and so differs from the id the registry would
+    // otherwise commit. This is the condition an id-squatting attacker relies on.
+    collided: boolean;
+}
+
+/**
+ * An optional consumer-supplied hook that decides the id a streamer is allowed to register as.
+ * Return the id to commit (the sanitized id to accept the default, or any other unique id to
+ * override, e.g. to namespace per tenant), or null to reject the streamer and disconnect it.
+ * This is the seam for implementing anti-squatting / ownership policy without the project
+ * providing an authentication scheme.
+ */
+export type StreamerIdAuthorizer = (request: IStreamerIdAuthRequest) => string | null;
 
 /**
  * Used by the API to describe a streamer.
@@ -49,10 +82,15 @@ export interface IStreamerInfo {
 export class StreamerRegistry extends EventEmitter {
     streamers: IStreamer[];
     defaultStreamerIdPrefix: string = 'UnknownStreamer';
+    // Optional consumer hook to authorize/override the id a streamer registers as. See
+    // {@link StreamerIdAuthorizer}. When unset the registry keeps its default behaviour of
+    // accepting the requested id and appending a numeric suffix on collision.
+    authorizeStreamerId?: StreamerIdAuthorizer;
 
-    constructor() {
+    constructor(authorizeStreamerId?: StreamerIdAuthorizer) {
         super();
         this.streamers = [];
+        this.authorizeStreamerId = authorizeStreamerId;
     }
 
     /**
@@ -139,7 +177,42 @@ export class StreamerRegistry extends EventEmitter {
         const oldId = streamer.streamerId;
 
         // id might conflict or be invalid so here we sanitize it
-        streamer.streamerId = this.sanitizeStreamerId(message.id);
+        const sanitizedId = this.sanitizeStreamerId(message.id);
+
+        let committedId: string | null = sanitizedId;
+        if (this.authorizeStreamerId) {
+            // Let the consumer accept the default id, override it (e.g. namespace per tenant), or
+            // reject the registration entirely. This is where anti-squatting policy lives.
+            committedId = this.authorizeStreamerId({
+                streamer,
+                requestedId: message.id,
+                sanitizedId,
+                collided: !!message.id && sanitizedId !== message.id
+            });
+
+            if (committedId === null) {
+                Logger.warn(
+                    `StreamerRegistry: streamer id '${message.id}' (was ${oldId}) rejected by authorizer. Disconnecting.`
+                );
+                this.remove(streamer);
+                streamer.protocol.disconnect(1008, 'streamer id not authorized');
+                return;
+            }
+
+            // An override must remain unique or it would corrupt id-based lookups. If the consumer
+            // hands back an id already held by a different streamer we reject rather than clobber.
+            const existing = this.find(committedId);
+            if (existing && existing !== streamer) {
+                Logger.error(
+                    `StreamerRegistry: authorizer returned id '${committedId}' which is already in use. Disconnecting.`
+                );
+                this.remove(streamer);
+                streamer.protocol.disconnect(1008, 'streamer id not authorized');
+                return;
+            }
+        }
+
+        streamer.streamerId = committedId;
 
         Logger.debug(`StreamerRegistry: Streamer id change. ${oldId} -> ${streamer.streamerId}`);
         streamer.emit('id_changed', streamer.streamerId);


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
Manual backport of [#921](https://github.com/EpicGames/PixelStreamingInfrastructure/pull/921) from `master` to `UE5.6`. It reached UE5.7 as #930 and is in UE5.8 via master's history, but UE5.6 never received it, so that branch has none of the consumer-auth seams: no `IStreamer.request` / `IPlayer.request`, no `IServerConfig.authorizeStreamerId`, and no "Authenticating and authorizing connections" section in the security guidelines.

That gap is what makes #956 (per-connection TURN credentials) expensive to backport to UE5.6 — #956 extends both the `IServerConfig` hook list and that documentation section, so against UE5.6 without this the whole section arrives as one conflicting block needing editorial rework. With #921 in place the problem disappears.

Follows #975, which backported the other prerequisite (#912) and is now merged.

## Solution
Cherry-pick of `8385df98` with two conflicts resolved by hand. Both were package-suffix collisions only; no logic was touched.

- `Signalling/src/PlayerRegistry.ts` and `Signalling/src/StreamerRegistry.ts` — #921 adds `import type { IncomingMessage } from 'http'` next to the `@epicgames-ps/lib-pixelstreamingcommon-*` import, and the incoming version named `-ue5.7`. Resolved by taking the incoming hunk and correcting the suffix to `-ue5.6`.
- `Signalling/src/{SignallingServer,StreamerConnection,PlayerConnection,SFUConnection}.ts`, `Docs/Security-Guidelines.md`, `.changeset/streamer-id-authorizer-hook.md` — applied clean.

The diff is now exactly #921's own 8 files, matching `master` line for line.

The changeset still names `-ue5.7`; `.github/scripts/version-with-normalized-suffixes.sh` rewrites that at release time, so it is left as the cherry-pick produced it.

## Documentation
`Docs/Security-Guidelines.md` gains the "Authenticating and authorizing connections" section, identical to `master` and UE5.7: the `verifyClient` pass-through, recovering the authenticated identity from the upgrade request, and authorizing the streamer id.

## Test Plan and Compatibility
`npm run build` and `npm run lint` pass in `Common`, `Signalling` and `SignallingWebServer` on Node 22.14.0, re-run after the rebase onto the merged UE5.6 tip.

Verified the auth seams are coherent on this branch rather than just compiling: `SignallingServer` passes the upgrade `request` into all three connection constructors, `StreamerRegistry` takes and consults `authorizeStreamerId`, and `IServerConfig` exposes it.

Confirmed no `-ue5.7` references remain under `Signalling/src`, `SignallingWebServer/src` or `Docs/` after the resolution.

Confirmed the intended payoff: with #975 and this commit applied, `fab376e9` (#956) cherry-picks onto UE5.6 with zero conflicts, where against UE5.6 without them it conflicts in both `Signalling/src/SignallingServer.ts` and `Docs/Security-Guidelines.md`.

Default behaviour is unchanged — both seams are optional and unset by default, matching #921 on `master`.
