### PR TITLE
feat(signalling): add an optional shared token on the player port

### DIFF
--- a/.changeset/player-token-gate.md
+++ b/.changeset/player-token-gate.md
@@ -1,0 +1,5 @@
+---
+'@epicgames-ps/wilbur': minor
+---
+
+Add `--player_token` (or `--player_token_file`), an optional shared token that a player must present to connect. It is checked with the `playerWsOptions.verifyClient` seam the security guidelines already recommend, so a player that cannot present it is refused during the HTTP upgrade with `401` and never becomes a connection — which is what keeps the config message, and any TURN credential in its peer options, away from it. The token is accepted as a `?token=` query parameter or an `Authorization: Bearer` header, compared over SHA-256 digests so neither its length nor the position of the first difference is observable, removed from the request before the connection is logged, and kept out of `--save`, the `--log_config` dump, the `--stdin` config dump and — when `--player_token_file` is used — the process command line. Each refusal is logged with its source address, since the player port is not covered by the HTTP rate limiter. Streamer and SFU connections are unaffected, and no player connection is refused when no token is supplied. See `Docs/Security-Guidelines.md`.

--- a/.changeset/stdin-config-dump-secrets.md
+++ b/.changeset/stdin-config-dump-secrets.md
@@ -1,0 +1,5 @@
+---
+'@epicgames-ps/wilbur': patch
+---
+
+Redact `turn_secret` and `player_token` in the interactive config dump. Pressing `c` with `--stdin` wrote the whole options object to stdout, and a service supervisor routinely redirects stdout to a file — so the dump put a secret on disk just as surely as the `--log_config` dump it was already redacted in.

--- a/Docs/Security-Guidelines.md
+++ b/Docs/Security-Guidelines.md
@@ -21,7 +21,7 @@ By following these tips, you can enhance the security of your Pixel Streaming se
 
 ## Authenticating and authorizing connections
 
-The signalling server **intentionally ships no authentication**. The streamer, player and SFU ports accept any connection, and any deployment is expected to bring its own authentication and authorization appropriate to its environment. In particular, the streamer port is designed to sit on a trusted/private network and should never be exposed directly to the internet without a front door of your own.
+The signalling server **intentionally ships no authentication beyond an optional shared token on the player port** ([below](#a-shared-token-on-the-player-port)) — no identity, no sessions, no login flow. The streamer and SFU ports accept any connection, and any deployment is expected to bring its own authentication and authorization appropriate to its environment. In particular, the streamer port is designed to sit on a trusted/private network and should never be exposed directly to the internet without a front door of your own.
 
 To make it practical to add your own auth without forking, the `Signalling` library exposes a few seams. None of these provide credentials or a login flow — they are hooks where *your* policy plugs in.
 
@@ -46,6 +46,40 @@ const server = new SignallingServer({
     }
 });
 ```
+
+#### A shared token on the player port
+
+The signalling server application implements the simplest useful case on top of that hook, for a deployment that needs a door rather than an identity — a kiosk, an internal demo, a staging environment that should not be open to whoever finds the address.
+
+Give it `--player_token <token>` (or `--player_token_file`) and every player must present that token to connect, either as a `?token=` query parameter or an `Authorization: Bearer` header. A player that does not is refused at the HTTP upgrade with `401`, so it never becomes a connection and is never sent the config message. Streamer and SFU connections are unaffected.
+
+```
+wilbur --player_token 8f14e45f-ea8d-4b3f-b6de-1cd97b4e2d21
+```
+
+The token has to reach the **signalling WebSocket**, which is not the same thing as the page URL. The bundled frontend builds its signalling URL from the page's protocol, hostname and port and nothing else, so putting `?token=` on the page address does not do it — the page loads normally and then the stream silently never starts. Give it the whole signalling URL instead, with the frontend's `ss` setting:
+
+```
+https://your-server/?ss=wss%3A%2F%2Fyour-server%2F%3Ftoken%3D8f14e45f-ea8d-4b3f-b6de-1cd97b4e2d21
+```
+
+A deployment serving its own page can do better than that by constructing the URL itself, which is what most will want:
+
+```ts
+const stream = new PixelStreaming(config); // config with SignallingServerUrl already set to
+                                           // `wss://your-server/?token=${yourToken}`
+```
+
+It is **one shared token, the same for everybody** — it does not identify a user, it does not expire, and revoking it means restarting the server with a new one. It answers "may this connection exist at all", which is the question a `--turn_secret` deliberately does not answer. If you need sessions, per-user revocation, or an identity attached to a connection, supply your own `verifyClient` instead; the flag exists so that a deployment which genuinely only needs a door does not have to fork the reference server to get one.
+
+Four things to know before relying on it:
+
+- **It gates one of three doors.** Streamer and SFU connections are also sent the config message, and are also unauthenticated. Gating players while leaving the streamer port reachable from the internet moves the problem rather than solving it — firewall those ports as tip 1 describes.
+- **Nothing rate limits guessing.** The `express-rate-limit` middleware only sees HTTP requests, and a WebSocket upgrade is a separate event it never sees, so a wrong token costs an attacker one round trip. Each refusal is logged with its source address, and the server warns at startup about a token short enough to matter. Use a long random one — a GUID is a good default.
+- **A token in a query string is visible to anything that logs URLs** — a reverse proxy's access log, browser history, and the frontend's own console line naming the URL it is connecting to — and it is the only option a browser has, since a WebSocket opened from a page cannot set headers. The server removes it from its own connection log, but it cannot reach anything in front of it. Serve over `https`/`wss`, and prefer the `Authorization` header wherever the client is not a browser.
+- **It is compared byte for byte.** A `+` in a query string means a space, and two Unicode spellings of the same text are different tokens. A GUID avoids both.
+
+If `--rest_api` is enabled, note that `GET /api/config` returns the peer options — including any static TURN credentials in them — to any HTTP caller, with no token required. That endpoint is unauthenticated by design and predates this flag; gate it with your own middleware, or use `--turn_secret` so the only credentials it can disclose are ones no peer was issued.
 
 ### Recovering the authenticated identity
 
@@ -90,6 +124,6 @@ Three things are worth understanding before choosing a TTL:
 
 - **Only players are given a limited credential.** A streamer or SFU receives its configuration once, when it connects, and there is no message that replaces it — so an expiry there would set a deadline on the stream rather than on an attacker. Those peers are issued a credential that outlives any plausible uptime. The exposure this feature exists to close is a credential shared by every browser that loads a page; a streamer is deployed by the operator on a host they control. If you want it rotated too, use `peerOptionsProvider` directly.
 - **A TTL may gate only the allocation, not the session.** Some TURN servers check the credential when a relay is allocated and not again, so a session already running continues past the expiry; others may re-check. Check your server before assuming a short TTL cannot interrupt a long call — with coturn, allocations have been reported to survive it.
-- **It does not decide who may obtain a credential.** Anything that can open a player WebSocket is sent one, so a short TTL limits how long a leaked credential stays useful, not who is issued one. Use the WebSocket upgrade hook above for that.
+- **It does not decide who may obtain a credential.** Anything that can open a player WebSocket is sent one, so a short TTL limits how long a leaked credential stays useful, not who is issued one. Use the WebSocket upgrade hook above for that — [`--player_token`](#a-shared-token-on-the-player-port) is the built-in way, and the server warns at startup when it is issuing TURN credentials without one.
 
 These hooks are deliberately policy-free: the library gives you the connection, its request, and the id it is asking for — what counts as a valid token, a permitted id or a valid credential is entirely up to your deployment.

--- a/SignallingWebServer/README.md
+++ b/SignallingWebServer/README.md
@@ -66,6 +66,9 @@ Options:
   --turn_secret_file <filename>
                                 Reads the value of --turn_secret from a file, so the secret does not appear in the command line of this process. (default: "")
   --turn_ttl <seconds>          How long a credential issued to a player stays valid. Streamers and SFUs are configured once and cannot be reissued, so they are given a credential that does not practically expire. (default: "86400")
+  --player_token <token>        Requires every player to present this token when it connects, as a ?token= query parameter or an Authorization: Bearer header. A player that does not is refused at the HTTP upgrade with 401, before it is sent the config message. Streamer and SFU connections are not affected. (default: "")
+  --player_token_file <filename>
+                                Reads the value of --player_token from a file, so the token does not appear in the command line of this process. (default: "")
   --log_config                  Will print the program configuration on startup. (default: true)
   --stdin                       Allows stdin input while running. (default: false)
   --save                        After arguments are parsed the config.json is saved with whatever arguments were specified at launch. (default: false)

--- a/SignallingWebServer/src/InputHandler.ts
+++ b/SignallingWebServer/src/InputHandler.ts
@@ -44,8 +44,19 @@ export function initInputHandler(options: IProgramOptions, signallingServer: Sig
     });
 }
 
+/** Options whose value is a credential, and must not be printed. See printConfig. */
+const SECRET_OPTIONS = ['turn_secret', 'player_token'];
+
 function printConfig(options: IProgramOptions) {
-    process.stdout.write(`${beautify(options)}\n`);
+    // Redacted like the --log_config dump, and for the same reason: stdout is routinely redirected
+    // to a file by a service supervisor, so printing a secret here writes it to disk just as surely.
+    const printable = { ...options };
+    for (const key of SECRET_OPTIONS) {
+        if (printable[key]) {
+            printable[key] = '<redacted>';
+        }
+    }
+    process.stdout.write(`${beautify(printable)}\n`);
 }
 
 function printServerInfo(_options: IProgramOptions, _signallingServer: SignallingServer) {

--- a/SignallingWebServer/src/index.ts
+++ b/SignallingWebServer/src/index.ts
@@ -11,6 +11,7 @@ import {
     IWebServerConfig
 } from '@epicgames-ps/lib-pixelstreamingsignalling-ue5.8';
 import { beautify, IProgramOptions } from './Utils';
+import { createPlayerTokenVerifier } from './playerAuth';
 import { createTurnCredentialsProvider, hasCredentiallessTurnServer } from './turnCredentials';
 import { initInputHandler } from './InputHandler';
 import { Command, Option } from 'commander';
@@ -24,6 +25,9 @@ import streamerByIdHandler from './paths/streamers/{streamerId}';
 
 // eslint-disable-next-line  @typescript-eslint/no-unsafe-assignment
 const pjson = require('../package.json');
+
+/** Below this a token is worth warning about; see where it is used for why it is only a warning. */
+const MINIMUM_PLAYER_TOKEN_LENGTH = 16;
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument */
 // possible config file options
@@ -207,6 +211,22 @@ program
         'How long a credential issued to a player stays valid. Streamers and SFUs are configured once and cannot be reissued, so they are given a credential that does not practically expire.',
         config_file.turn_ttl || '86400'
     )
+    // The default below uses `??` rather than the `||` every option around it uses, deliberately: a
+    // falsy value written in a config file is a mistake worth reporting, and `||` would collapse `0`
+    // and `false` into "no token configured" before anything downstream could tell the difference -
+    // silently leaving the player port open on a deployment that asked for it to be closed.
+    .addOption(
+        new Option(
+            '--player_token <token>',
+            'Requires every player to present this token when it connects, as a ?token= query parameter or an Authorization: Bearer header. A player that does not is refused at the HTTP upgrade with 401, before it is sent the config message. Streamer and SFU connections are not affected.'
+        ).default(config_file.player_token ?? '')
+    )
+    .addOption(
+        new Option(
+            '--player_token_file <filename>',
+            'Reads the value of --player_token from a file, so the token does not appear in the command line of this process.'
+        ).default(config_file.player_token_file || '')
+    )
     .option(
         '--reverse-proxy',
         'Enables reverse proxy mode. This will trust the X-Forwarded-For header.',
@@ -246,8 +266,9 @@ if (options.save) {
     delete save_options.no_config;
     delete save_options.config_file;
     delete save_options.save;
-    // The secret itself never goes to disk here; turn_secret_file is only a path, so it stays.
+    // The secrets themselves never go to disk here; the *_file options are only paths, so they stay.
     delete save_options.turn_secret;
+    delete save_options.player_token;
 
     // save out the config file with the current settings
     fs.writeFile(configArgsParser.config_file, beautify(save_options), (error: any) => {
@@ -276,23 +297,36 @@ if (options.peer_options_file) {
     );
 }
 
+/**
+ * Reads a secret that was supplied as a file rather than on the command line.
+ *
+ * Trimmed because the usual way to write one of these is `echo $SECRET > secret.txt`, which leaves a
+ * trailing newline. An empty file throws rather than returning nothing, because an empty secret
+ * reads as "this feature was not configured" and silently starts the server with it off - which
+ * looks identical to it working until the first peer needs it.
+ */
+function readSecretFile(filename: string, optionName: string): string {
+    if (!fs.existsSync(filename)) {
+        Logger.error(`${optionName} "${filename}" does not exist.`);
+        throw Error(`Failed to find the file ${filename} given to ${optionName}.`);
+    }
+
+    const secret = fs.readFileSync(filename, 'utf-8').trim();
+    if (!secret) {
+        Logger.error(`${optionName} "${filename}" is empty.`);
+        throw Error(`The file ${filename} given to ${optionName} contains no value.`);
+    }
+    return secret;
+}
+
 // read the turn_secret_file
 if (options.turn_secret_file) {
-    if (!fs.existsSync(options.turn_secret_file)) {
-        Logger.error(`turn_secret_file "${options.turn_secret_file}" does not exist.`);
-        throw Error(`Failed to find a turn secret file called ${options.turn_secret_file}.`);
-    }
+    options.turn_secret = readSecretFile(options.turn_secret_file, 'turn_secret_file');
+}
 
-    // Trimmed because the usual way to write one of these is `echo $SECRET > secret.txt`, which
-    // leaves a trailing newline that would silently produce credentials the TURN server rejects.
-    options.turn_secret = fs.readFileSync(options.turn_secret_file, 'utf-8').trim();
-
-    // An empty file would otherwise read as "no secret configured" and silently start the server
-    // with the feature off, which looks identical to it working until a peer tries to relay.
-    if (!options.turn_secret) {
-        Logger.error(`turn_secret_file "${options.turn_secret_file}" is empty.`);
-        throw Error(`The turn secret file ${options.turn_secret_file} contains no secret.`);
-    }
+// read the player_token_file
+if (options.player_token_file) {
+    options.player_token = readSecretFile(options.player_token_file, 'player_token_file');
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -302,7 +336,8 @@ if (options.log_config) {
     for (const key in options) {
         // The config dump goes to the log file, which is kept and rotated - a secret written there
         // is a secret in every backup of this machine.
-        const value: unknown = key === 'turn_secret' && options[key] ? '<redacted>' : options[key];
+        const secret = key === 'turn_secret' || key === 'player_token';
+        const value: unknown = secret && options[key] ? '<redacted>' : options[key];
         Logger.info(`"${key}": ${JSON.stringify(value)}`);
     }
 }
@@ -321,6 +356,63 @@ const serverOpts: IServerConfig = {
     playerKeepaliveTimeout: Number(options.player_keepalive_timeout)
 };
 
+// A shared token on the player port, when one was supplied. This runs at the HTTP upgrade, so a
+// player that cannot present it never becomes a connection and is never sent the config message -
+// which is what keeps the peer options, and any TURN credential in them, away from it.
+// Coerced rather than type checked. A config.json is hand written, and `"player_token": 12345678`
+// arrives here as a number - which a `typeof` guard would quietly turn into an open player port,
+// while the startup dump went on printing <redacted> and implying a token was in force. Whatever was
+// supplied is a token; only the absence of one leaves the port open.
+const rawPlayerToken: unknown = options.player_token;
+let playerToken = '';
+if (typeof rawPlayerToken === 'string') {
+    playerToken = rawPlayerToken;
+} else if (typeof rawPlayerToken === 'number') {
+    // JSON has one number type, so `"player_token": 12345678` is a number here. Coerced rather than
+    // rejected, because the operator plainly meant it as a token - but said out loud, because the
+    // coercion is not always the text they wrote: a long integer loses precision and 1e21 becomes
+    // "1e+21", where the `+` decodes to a space and the query parameter route can never work.
+    playerToken = String(rawPlayerToken);
+    Logger.warn(
+        `player_token was given as a number and is being used as the text "${playerToken}". ` +
+            'Quote it in the config file to be sure of what clients must send.'
+    );
+}
+if (playerToken) {
+    // Nothing rate limits this port: express-rate-limit is Express middleware, and an upgrade is a
+    // different event that Express never sees. So a refusal is logged - the address only, never what
+    // was presented - because an operator who cannot see guessing cannot respond to it.
+    serverOpts.playerWsOptions = {
+        ...serverOpts.playerWsOptions,
+        verifyClient: createPlayerTokenVerifier(playerToken, (request) => {
+            Logger.warn(`Refused a player from %s: no valid token.`, request.socket.remoteAddress);
+        })
+    };
+
+    // Short enough to guess, given the above. Warned rather than refused: the length that is "enough"
+    // depends on a deployment's exposure, and this is not the place to overrule an operator.
+    if (playerToken.length < MINIMUM_PLAYER_TOKEN_LENGTH) {
+        Logger.warn(
+            `player_token is only ${playerToken.length} characters. Nothing rate limits the player ` +
+                'port, so a short token can be guessed quickly. A GUID is a good default.'
+        );
+    }
+    Logger.info('Players must present --player_token to connect.');
+} else if (
+    options.player_token_file ||
+    (rawPlayerToken !== undefined && rawPlayerToken !== null && rawPlayerToken !== '')
+) {
+    // Something was configured and it came to nothing - `true`, an array, an object. Refusing to
+    // start is the only honest answer: carrying on would leave the player port open on a deployment
+    // whose operator has said in writing that it should not be.
+    //
+    // An explicitly empty string is excluded, and means what it says: no token. The throw beats
+    // winston's flush, so this reason reaches the console and stderr but not the log file - which is
+    // also true of the turn_ttl and secret file validation above it.
+    Logger.error('A player token was configured but is empty; refusing to start with an open player port.');
+    throw Error('Invalid player_token.');
+}
+
 // Time limited TURN credentials, when a shared secret was supplied. Without one the static username
 // and credential in the peer options are sent to every peer exactly as before.
 if (options.turn_secret) {
@@ -338,6 +430,16 @@ if (options.turn_secret) {
         ttlSeconds: turnTtlSeconds
     });
     Logger.info(`Issuing time limited TURN credentials, valid for ${turnTtlSeconds} seconds.`);
+    if (!options.player_token) {
+        // Worth saying together, because the two halves are easy to mistake for one another. A TTL
+        // decides how long a credential stays usable; it does not decide who is given one, and
+        // anything that can open a player socket is given one.
+        Logger.warn(
+            'TURN credentials are issued to every player that connects, because no --player_token ' +
+                'was supplied. A short --turn_ttl limits how long a leaked credential lasts, not ' +
+                'who receives one.'
+        );
+    }
 } else if (hasCredentiallessTurnServer(options.peer_options)) {
     // Nothing is going to fill these in, and a peer that receives a TURN server it cannot
     // authenticate against fails later, at ICE, as a generic connection failure with nothing in

--- a/SignallingWebServer/src/playerAuth.test.ts
+++ b/SignallingWebServer/src/playerAuth.test.ts
@@ -1,0 +1,194 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+import http from 'http';
+import { createPlayerTokenVerifier } from './playerAuth';
+
+/** Builds the argument ws passes to verifyClient, with only the parts this code reads. */
+function upgradeRequest(options: { url?: string; authorization?: string }) {
+    const headers: http.IncomingHttpHeaders = {};
+    if (options.authorization !== undefined) {
+        headers.authorization = options.authorization;
+    }
+    return {
+        origin: '',
+        secure: false,
+        req: { url: options.url, headers } as http.IncomingMessage
+    };
+}
+
+/** Runs a verifier and returns what it answered, plus the url the request was left holding. */
+function verify(token: string, options: { url?: string; authorization?: string }) {
+    const verifier = createPlayerTokenVerifier(token);
+    const request = upgradeRequest(options);
+    let result: { allowed: boolean; code?: number; message?: string; url?: string } | undefined;
+    verifier(request, (allowed, code, message) => {
+        result = { allowed, code, message, url: request.req.url };
+    });
+    return result;
+}
+
+describe('player token verifier', () => {
+    it('admits a connection presenting the token as a query parameter', () => {
+        expect(verify('opensesame', { url: '/?token=opensesame' })?.allowed).toBe(true);
+    });
+
+    it('admits a connection presenting the token as a bearer header', () => {
+        expect(verify('opensesame', { authorization: 'Bearer opensesame' })?.allowed).toBe(true);
+    });
+
+    it('accepts the bearer scheme in any case', () => {
+        expect(verify('opensesame', { authorization: 'bearer opensesame' })?.allowed).toBe(true);
+    });
+
+    it('reads the token from a url that has other parameters', () => {
+        expect(verify('opensesame', { url: '/?foo=bar&token=opensesame&baz=1' })?.allowed).toBe(true);
+    });
+
+    it('refuses a connection presenting the wrong token', () => {
+        const result = verify('opensesame', { url: '/?token=letmein' });
+        expect(result?.allowed).toBe(false);
+        expect(result?.code).toBe(401);
+    });
+
+    it('refuses a connection presenting no token at all', () => {
+        expect(verify('opensesame', { url: '/' })?.allowed).toBe(false);
+    });
+
+    it('refuses a connection whose token is a prefix of the expected one', () => {
+        expect(verify('opensesame', { url: '/?token=open' })?.allowed).toBe(false);
+    });
+
+    it('refuses an empty token', () => {
+        expect(verify('opensesame', { url: '/?token=' })?.allowed).toBe(false);
+    });
+
+    it('refuses a request with no url', () => {
+        expect(verify('opensesame', {})?.allowed).toBe(false);
+    });
+
+    it('ignores an authorization header that is not a bearer', () => {
+        expect(verify('opensesame', { authorization: 'Basic opensesame' })?.allowed).toBe(false);
+    });
+
+    it('accepts a correct header alongside a wrong query token', () => {
+        expect(
+            verify('opensesame', { url: '/?token=letmein', authorization: 'Bearer opensesame' })
+                ?.allowed
+        ).toBe(true);
+    });
+
+    // Neither place takes precedence. A wrong header used to end the matter, so anything in front of
+    // the server that injects an Authorization header disabled the only route a browser has.
+    it('accepts a correct query token alongside a wrong header', () => {
+        expect(
+            verify('opensesame', { url: '/?token=opensesame', authorization: 'Bearer letmein' })
+                ?.allowed
+        ).toBe(true);
+    });
+
+    // Same defect one layer along: a proxy that PREPENDS its own token parameter would break the
+    // query route if only the first were read.
+    it('accepts a correct token that is not the first one presented', () => {
+        const result = verify('opensesame', { url: '/?token=letmein&token=opensesame' });
+        expect(result?.allowed).toBe(true);
+        // And both are removed, so neither survives into the log.
+        expect(result?.url).toBe('/');
+    });
+
+    it('url decodes a token before comparing it', () => {
+        expect(verify('a b', { url: `/?token=${encodeURIComponent('a b')}` })?.allowed).toBe(true);
+    });
+
+    // Node's HTTP parser accepts request targets the URL constructor rejects. A throw here escapes
+    // through ws's upgrade handler and ends the process, so every one of these must be a plain
+    // refusal - reachable by anyone who can open a socket, without presenting anything.
+    describe('request targets that are not valid URLs', () => {
+        it.each(['//', '///', '//:', '//\\', 'http://[', '// ', '//?token=opensesame'])(
+            'refuses %p without throwing',
+            (url) => {
+                expect(() => verify('opensesame', { url })).not.toThrow();
+                expect(verify('opensesame', { url })?.allowed).toBe(false);
+            }
+        );
+
+        it('does not throw when the token is valid but the target is not parseable', () => {
+            // The header is read before the url, so this reaches stripToken rather than the parse.
+            const result = verify('opensesame', { url: '//', authorization: 'Bearer opensesame' });
+            expect(result?.allowed).toBe(true);
+        });
+    });
+
+    describe('removing the token from an accepted request', () => {
+        // The signalling server logs the url a player connected with, and that log is rotated and
+        // backed up. Without this the token is written to disk on every single connection.
+        it('takes the token out of the url', () => {
+            expect(verify('opensesame', { url: '/?token=opensesame' })?.url).toBe('/');
+        });
+
+        it('keeps the path and every other parameter', () => {
+            expect(verify('opensesame', { url: '/ws?StreamerId=abc&token=opensesame&x=1' })?.url).toBe(
+                '/ws?StreamerId=abc&x=1'
+            );
+        });
+
+        it('leaves a url that never carried a token alone', () => {
+            expect(verify('opensesame', { url: '/ws?x=1', authorization: 'Bearer opensesame' })?.url).toBe(
+                '/ws?x=1'
+            );
+        });
+
+        it('leaves the url of a refused connection alone', () => {
+            expect(verify('opensesame', { url: '/?token=letmein' })?.url).toBe('/?token=letmein');
+        });
+
+        // A semicolon is not a parameter separator: URLSearchParams stopped treating it as one when
+        // it moved to the WHATWG rules, so `a=1;token=x` is one parameter named `a`. Both sides here
+        // agree about that - the read side does not find a token, so such a request is refused and
+        // never reaches the splice. Pinned because the two sides MUST agree: if the reader saw a
+        // token the splicer did not, an accepted connection would keep its credential in the log.
+        // Do not "fix" the splice to split on `;` as well - that would break any value containing one.
+        it('does not treat a semicolon as a parameter separator', () => {
+            expect(verify('opensesame', { url: '/?a=1;token=opensesame' })?.allowed).toBe(false);
+        });
+
+        it('leaves a semicolon inside another value alone', () => {
+            expect(verify('t', { url: '/ws?a=1;2&token=t' })?.url).toBe('/ws?a=1;2');
+        });
+
+        // The URL parser strips tab, CR and LF before parsing, so `to<tab>ken` IS the token
+        // parameter to the reading side. If the splice disagreed, such a request would be accepted
+        // and keep its credential in the target that gets logged. Node's HTTP parser rejects these
+        // with 400 before they ever arrive, but createPlayerTokenVerifier is exported and a consumer
+        // driving it from a manual `upgrade` handler is not bound by that.
+        it.each(['/?to\tken=opensesame', '/?to\nken=opensesame', '/?to\rken=opensesame'])(
+            'reads and removes the token from %j alike',
+            (url) => {
+                const result = verify('opensesame', { url });
+                expect(result?.allowed).toBe(true);
+                expect(result?.url).not.toContain('opensesame');
+            }
+        );
+
+        it('leaves a path behind rather than an empty url', () => {
+            expect(verify('opensesame', { url: '?token=opensesame' })?.url).toBe('/');
+        });
+
+        it('removes a token whose key was percent encoded', () => {
+            // URLSearchParams decodes the key, so this IS the token parameter as far as the read
+            // side is concerned. If the two sides disagreed, the credential would survive the strip.
+            expect(verify('opensesame', { url: '/?%74oken=opensesame' })?.url).toBe('/');
+        });
+
+        // Rebuilding the target from a parsed URL changes all of these; splicing does not. The
+        // request is handed to consumer code, so leaving it as written is part of the contract.
+        it.each([
+            ['/ws?a=b%20c&token=t', '/ws?a=b%20c'],
+            ['/ws?flag&token=t', '/ws?flag'],
+            ["/ws?a=~!*()'&token=t", "/ws?a=~!*()'"],
+            ['/ws/../x?token=t', '/ws/../x'],
+            ['/ws?token=t#frag', '/ws#frag'],
+            ['/ws?x=1&token=t&x=2', '/ws?x=1&x=2']
+        ])('leaves %p as %p', (url, expected) => {
+            expect(verify('t', { url })?.url).toBe(expected);
+        });
+    });
+});

--- a/SignallingWebServer/src/playerAuth.ts
+++ b/SignallingWebServer/src/playerAuth.ts
@@ -1,0 +1,191 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+import crypto from 'crypto';
+import http from 'http';
+
+/**
+ * The shape ws expects for verifyClient in its callback form. Declared here rather than imported so
+ * this module does not depend on which ws types happen to be hoisted.
+ */
+export type VerifyClient = (
+    info: { origin: string; secure: boolean; req: http.IncomingMessage },
+    callback: (result: boolean, code?: number, message?: string) => void
+) => void;
+
+/** Called when a connection is refused, so the caller can say so without this module logging. */
+export type OnRefused = (request: http.IncomingMessage) => void;
+
+/**
+ * Parses a request target, returning null rather than throwing when it is not one.
+ *
+ * This has to fail rather than throw. `request.url` is whatever the client put on the request line,
+ * and Node's HTTP parser accepts targets the URL constructor rejects - `//` is the shortest of them.
+ * A throw here escapes through ws's upgrade handler, and with no uncaughtException handler anywhere
+ * in the project that ends the process: one unauthenticated packet, taking every connected player
+ * and the streamer with it. A request we cannot parse is simply a request presenting no token.
+ */
+function parseRequestTarget(target: string): URL | null {
+    try {
+        // The base is required by the constructor and otherwise unused - an upgrade request's target
+        // is normally a path, though a client may legally send an absolute form.
+        return new URL(target, 'http://localhost');
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Decodes a query string key the way URLSearchParams does, so `%74oken` is recognised as `token`.
+ * A key with a malformed escape in it is returned as written, which cannot match and so fails closed.
+ *
+ * The tab and newline removal matters, and is not decoration: the URL parser strips U+0009, U+000A
+ * and U+000D from its input before parsing, so `to&lt;tab&gt;ken` is the `token` parameter as far as the
+ * reading side is concerned. If this disagreed, a request could present a token that is accepted and
+ * then not removed - leaving the credential in the target that gets logged. The two sides have to
+ * agree on what the token parameter is, in both directions.
+ */
+function decodeKey(key: string): string {
+    try {
+        return decodeURIComponent(key.replace(/[\t\n\r]/g, '').replace(/\+/g, ' '));
+    } catch {
+        return key;
+    }
+}
+
+/**
+ * Reads the token a client presented, from either place one can reasonably be put.
+ *
+ * A query parameter is what a browser can send, because a WebSocket opened from a page cannot carry
+ * custom headers. The Authorization header is for everything that is not a browser - a test harness,
+ * a proxy, a native client - where a credential in a URL would end up in logs and history.
+ *
+ * Note that a query string is form encoded, so a `+` in a token arrives as a space, and that a token
+ * is compared byte for byte, so two Unicode spellings of the same text do not match. Issue tokens
+ * that survive both (a GUID does) or send the header instead.
+ *
+ * Both places are read rather than one taking precedence over the other. A header that is present
+ * but wrong used to end the matter, which would make anything in front of this server that injects
+ * an Authorization header silently disable the only route a browser has.
+ *
+ * @param request - The HTTP upgrade request.
+ * @returns Every token presented, in no significant order. Empty when none was.
+ */
+function tokensFromRequest(request: http.IncomingMessage): string[] {
+    const presented: string[] = [];
+
+    const authorization = request.headers.authorization;
+    if (authorization) {
+        // Case insensitive: the scheme in an Authorization header is a token, and RFC 9110 defines
+        // token comparison as case insensitive. A client sending `bearer` is not wrong.
+        const bearer = /^bearer\s+(.+)$/i.exec(authorization);
+        if (bearer) {
+            presented.push(bearer[1]);
+        }
+    }
+
+    if (request.url) {
+        // getAll, not get: `get` returns only the first, so a proxy that prepends its own `token`
+        // parameter would disable the query route exactly the way a wrong Authorization header used
+        // to. stripToken removes every `token` pair, so reading every one keeps the two sides square.
+        presented.push(...(parseRequestTarget(request.url)?.searchParams.getAll('token') ?? []));
+    }
+
+    return presented;
+}
+
+/**
+ * Removes the token from an accepted request's target, in place.
+ *
+ * The signalling server logs the target a player connected with, and that log is kept and rotated -
+ * so without this, enabling the token writes it into a file, and into every backup of the machine
+ * holding it, on every connection. A credential in a query string is exposed to whatever else
+ * handles the URL - a proxy's access log, browser history - which is why the Authorization header is
+ * the better option wherever a client can send one. This removes the copy that is ours to remove.
+ *
+ * The token parameter is spliced out of the raw string rather than the whole target being rebuilt
+ * from a parsed URL. Rebuilding is lossy in ways a consumer can see, and the request is handed to
+ * consumer code as the connection's `request`: re-serialising re-encodes every other value, gives a
+ * bare key an `=`, normalises dot segments in the path and drops any fragment. Splicing changes
+ * exactly the one parameter this module put there.
+ */
+function stripToken(request: http.IncomingMessage): void {
+    const target = request.url;
+    if (!target) {
+        return;
+    }
+
+    const queryStart = target.indexOf('?');
+    if (queryStart < 0) {
+        return;
+    }
+
+    // A fragment is not normally sent on a request line, but it is not ours to discard if it is.
+    const fragmentStart = target.indexOf('#', queryStart);
+    const path = target.slice(0, queryStart);
+    const query = target.slice(queryStart + 1, fragmentStart < 0 ? undefined : fragmentStart);
+    const fragment = fragmentStart < 0 ? '' : target.slice(fragmentStart);
+
+    const kept = query.split('&').filter((pair) => {
+        if (pair === '') {
+            return false;
+        }
+        const equals = pair.indexOf('=');
+        return decodeKey(equals < 0 ? pair : pair.slice(0, equals)) !== 'token';
+    });
+
+    // `path || '/'` because a target of `?token=x` carries no path at all, and leaving request.url
+    // as the empty string would be a stranger thing to hand on than the `/` it means.
+    request.url =
+        kept.length > 0 ? `${path || '/'}?${kept.join('&')}${fragment}` : `${path || '/'}${fragment}`;
+}
+
+/**
+ * Builds a verifyClient that admits only connections presenting the expected token.
+ *
+ * This runs during the HTTP upgrade, which is the point of it: a rejected connection never becomes a
+ * WebSocket, so it is never sent the config message - and therefore never receives the peer options,
+ * which is where a TURN credential lives.
+ *
+ * The scheme is deliberately the simplest one that is useful: a single shared token, compared
+ * literally. It is not a session, it does not expire and it does not identify anybody. A deployment
+ * needing more than that should supply its own verifyClient through playerWsOptions, which is what
+ * this is built on and what the security guidelines describe.
+ *
+ * @param token - The token every player must present.
+ * @param onRefused - Called with the request of each refused connection.
+ * @returns A verifyClient suitable for IServerConfig.playerWsOptions.
+ */
+export function createPlayerTokenVerifier(token: string, onRefused?: OnRefused): VerifyClient {
+    // Hashed once rather than per request. The digest is not the token and is never compared to
+    // anything an attacker supplies directly, so holding it costs nothing.
+    const expected = crypto.createHash('sha256').update(token).digest();
+
+    return (info, callback) => {
+        // `some` short circuits, so a request presenting two tokens is measurably cheaper when the
+        // first matches. That distinguishes states the client already knows it is in and says
+        // nothing about the expected token, which is the only secret here.
+        if (tokensFromRequest(info.req).some((presented) => secretsMatch(presented, expected))) {
+            stripToken(info.req);
+            callback(true);
+            return;
+        }
+
+        onRefused?.(info.req);
+        // 401 rather than 403, and a reason on the wire: a player that is refused sees only a failed
+        // WebSocket in its console, so the status code is the only thing distinguishing "you need a
+        // token" from "the server is down". Nothing about the expected token is disclosed by it.
+        callback(false, 401, 'Unauthorized');
+    };
+}
+
+/**
+ * Compares a presented secret against an expected digest, without leaking which character differed
+ * or how long the expected secret is.
+ *
+ * Both sides are hashed so the comparison is over two equal length digests. timingSafeEqual throws on
+ * a length mismatch, so comparing the raw strings would need a length check in front of it, and that
+ * check would answer "how long is the token" to anyone who asked enough times.
+ */
+function secretsMatch(presented: string, expected: Buffer): boolean {
+    const presentedDigest = crypto.createHash('sha256').update(presented).digest();
+    return crypto.timingSafeEqual(presentedDigest, expected);
+}


### PR DESCRIPTION
## Relevant components:
- [x] Signalling server
- [ ] Common library
- [ ] Frontend library
- [ ] Frontend UI library
- [ ] Matchmaker
- [ ] Platform scripts
- [ ] SFU

## Problem statement:
`Docs/Security-Guidelines.md` tells a deployment to authenticate at the WebSocket upgrade with a `verifyClient` on `playerWsOptions`, and that is the right place — it runs before the config message, so a refused peer is never sent `peerConnectionOptions`. But the signalling server gives you no way to reach that seam, so even the simplest version of it means forking the reference server.

`--turn_secret` made the gap more obvious. A time limited credential decides how long a leak stays usable, not who is issued one, and anything that can open a player socket is issued one.

## Solution
`--player_token` (or `--player_token_file`) requires a player to present a token, as a `?token=` query parameter or an `Authorization: Bearer` header. One that cannot is refused during the upgrade with `401`, so it never becomes a connection and never receives the config message. Streamer and SFU connections are untouched, and with no token configured `playerWsOptions` is not set at all.

It is deliberately the least ambitious useful thing: one shared token, the same for everyone, with no identity and no expiry. Enough for a kiosk or an internal demo, and the documentation says plainly that anything needing sessions or identity should supply its own `verifyClient` instead.

Two implementation notes, since both are easy to get wrong in a security feature. A request target that will not parse is refused rather than allowed to throw — Node's HTTP parser accepts targets `new URL()` rejects, and a throw inside `verifyClient` escapes through ws's upgrade handler and ends the process. And the token is removed from an accepted request before `SignallingServer` logs the URL it connected with, because that log is rotated and backed up.

Two things I would rather raise than have found:

**This is authentication, and the guidelines said the project ships none.** I have amended that sentence rather than leave it contradicting the new section below it. I think it belongs here for the same reason `--turn_secret` does — the library keeps the policy-free hook, the application implements the common case — but if you would rather the reference server stayed clear of it, I would genuinely rather hear that than have it merged reluctantly.

**The bundled frontend cannot use it unaided.** It builds its signalling URL from the page's protocol, host and port only, so a `?token=` on the page address never reaches the socket. The docs give the `?ss=` form that works today. Teaching `Config.ts` to carry the parameter through would make the obvious thing work, but it couples the frontend library to a flag name in the application, so I left it out — happy to add it if you would prefer.

## Documentation
A subsection under the upgrade hook in `Docs/Security-Guidelines.md`: what the flag is, what it is not, and the caveats worth knowing — it gates the player port only, nothing rate limits guessing, and a query string is visible to anything that logs URLs. It also notes that `--rest_api`'s `GET /api/config` already discloses peer options without a token. `SignallingWebServer/README.md` lists both options.

## Test Plan and Compatibility
39 unit tests: bypass attempts, both transports, malformed targets, and the URL rewriting. Also run against a live server — no token, a wrong one, a prefix and an empty one are each refused; both transports connect; every malformed target is refused with the server still serving afterwards; and the connection log shows the token absent. With no token configured, all of the same requests connect exactly as they do on `master`.

`npm run build`, `npm run lint` and `npm run test` pass for `SignallingWebServer`.
